### PR TITLE
Fix failing tests due to CTest quirk

### DIFF
--- a/Testing/CMake/AppLauncher-Settings-TestEnvironment-NotFound.cmake
+++ b/Testing/CMake/AppLauncher-Settings-TestEnvironment-NotFound.cmake
@@ -83,10 +83,9 @@ ${expected_regular_env_var_name_2}=${expected_regular_env_var_value_2}
 ${expected_regular_env_var_name_3}=${expected_regular_env_var_value_3}
 ${expected_regular_env_var_name_4}=${expected_regular_env_var_value_4}
 ")
+string(REPLACE "\r" "" expected_msg ${expected_msg})
 string(REGEX MATCH ${expected_msg} current_msg ${ov})
 if(NOT "${expected_msg}" STREQUAL "${current_msg}")
-message("expected: '${expected_msg}'")
-message("matched: '${current_msg}'")
   message(FATAL_ERROR "Failed to pass environment variable from ${launcher_name} "
                       "to ${application_name}.\n${ov}")
 endif()

--- a/Testing/CMake/AppLauncher-Settings-TestEnvironment.cmake
+++ b/Testing/CMake/AppLauncher-Settings-TestEnvironment.cmake
@@ -83,6 +83,7 @@ ${expected_regular_env_var_name_2}=${expected_regular_env_var_value_2}
 ${expected_regular_env_var_name_3}=${expected_regular_env_var_value_3}
 ${expected_regular_env_var_name_4}=${expected_regular_env_var_value_4}
 ")
+string(REPLACE "\r" "" expected_msg ${expected_msg})
 string(REGEX MATCH ${expected_msg} current_msg ${ov})
 if(NOT "${expected_msg}" STREQUAL "${current_msg}")
   message(FATAL_ERROR "Failed to pass environment variable from ${launcher_name} "


### PR DESCRIPTION
It seems that CTest (some versions at least) on Windows reads its scripts in binary mode, such that if the script has CRLF line endings, a multi-line string will also include the `\r` characters, which can cause our output matching to wrongly fail. Work around this by adding a step to strip out any `\r`s to ensure that the expected string has the intended value.

Also remove some debugging code that was accidentally left in a previous commit.
