### PR TITLE
Fix build against Qt < 4.8

### DIFF
--- a/Base/ctkAppLauncher.cpp
+++ b/Base/ctkAppLauncher.cpp
@@ -805,7 +805,15 @@ void ctkAppLauncher::generateEnvironmentScript(QTextStream &output, bool posix)
   QProcessEnvironment env;
 
   this->Internal->buildEnvironment(env);
+#if QT_VERSION >= 0x040800
   QStringList envKeys = env.keys();
+#else // emulate above on older versions of Qt
+  QStringList envKeys;
+  foreach (const QString& pair, env.toStringList())
+    {
+    envKeys.append(pair.split("=").first());
+    }
+#endif
   envKeys.sort();
 
   QSet<QString> appendVars = this->Internal->AdditionalPathVariables;


### PR DESCRIPTION
Add a fallback for QProcessEnvironment::keys(), which was added in Qt 4.8.
