### PR TITLE
Correctly fix tests on Windows

### DIFF
--- a/Testing/CMake/AppLauncher-Settings-TestEnvironment-NotFound.cmake
+++ b/Testing/CMake/AppLauncher-Settings-TestEnvironment-NotFound.cmake
@@ -83,8 +83,7 @@ ${expected_regular_env_var_name_2}=${expected_regular_env_var_value_2}
 ${expected_regular_env_var_name_3}=${expected_regular_env_var_value_3}
 ${expected_regular_env_var_name_4}=${expected_regular_env_var_value_4}
 ")
-string(REPLACE "\r" "" expected_msg ${expected_msg})
-string(REGEX MATCH ${expected_msg} current_msg ${ov})
+string(REGEX MATCH "${expected_msg}" current_msg "${ov}")
 if(NOT "${expected_msg}" STREQUAL "${current_msg}")
   message(FATAL_ERROR "Failed to pass environment variable from ${launcher_name} "
                       "to ${application_name}.\n${ov}")

--- a/Testing/CMake/AppLauncher-Settings-TestEnvironment.cmake
+++ b/Testing/CMake/AppLauncher-Settings-TestEnvironment.cmake
@@ -83,8 +83,7 @@ ${expected_regular_env_var_name_2}=${expected_regular_env_var_value_2}
 ${expected_regular_env_var_name_3}=${expected_regular_env_var_value_3}
 ${expected_regular_env_var_name_4}=${expected_regular_env_var_value_4}
 ")
-string(REPLACE "\r" "" expected_msg ${expected_msg})
-string(REGEX MATCH ${expected_msg} current_msg ${ov})
+string(REGEX MATCH "${expected_msg}" current_msg "${ov}")
 if(NOT "${expected_msg}" STREQUAL "${current_msg}")
   message(FATAL_ERROR "Failed to pass environment variable from ${launcher_name} "
                       "to ${application_name}.\n${ov}")


### PR DESCRIPTION
Quote strings where needed to prevent expected/actual output comparison from incorrectly removing `;`s. It turns out this was the actual problem with these tests, and not line endings as previously believed (see 8011e58756b6ce125943d7dfbadf02105c4a677e). The old work-around (now removed) happened to "fix" the problem by also stripping `;`s from the expected string, which allowed the compare to succeed and the test to pass.
