### PR TITLE
Docker support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,76 @@
+FROM thewtex/centos-build:v1.0.0
+MAINTAINER CommonTK Community <ctk-developers@commontk.org>
+# Build and package the CTK AppLauncher
+
+RUN yum update -y && \
+  yum install -y \
+    libX11-devel \
+    libXt-devel \
+    libXext-devel \
+    libXrender-devel
+
+WORKDIR /usr/src
+
+RUN wget http://packages.kitware.com/download/item/6175/qt-everywhere-opensource-src-4.8.6.tar.gz && \
+ md5=$(md5sum ./qt-everywhere-opensource-src-4.8.6.tar.gz | awk '{ print $1 }') && \
+ [ $md5 == "2edbe4d6c2eff33ef91732602f3518eb" ] && \
+ tar -xzvf qt-everywhere-opensource-src-4.8.6.tar.gz && \
+ rm qt-everywhere-opensource-src-4.8.6.tar.gz && \
+ mv qt-everywhere-opensource-src-4.8.6 qt-everywhere-opensource-release-src-4.8.6 && \
+ mkdir qt-everywhere-opensource-release-build-4.8.6 && \
+ cd qt-everywhere-opensource-release-src-4.8.6 && \
+ LD=${CXX} ./configure -prefix /usr/src/qt-everywhere-opensource-release-build-4.8.6 \
+   -confirm-license -opensource \
+   -static \
+   -release \
+   -no-largefile \
+   -no-exceptions \
+   -no-accessibility \
+   -no-sql-db2 \
+   -no-sql-ibase \
+   -no-sql-mysql \
+   -no-sql-oci \
+   -no-sql-odbc \
+   -no-sql-psql \
+   -no-sql-sqlite \
+   -no-sql-sqlite2 \
+   -no-sql-sqlite_symbian \
+   -no-sql-tds \
+   -no-qt3support \
+   -no-xmlpatterns \
+   -no-multimedia \
+   -no-audio-backend \
+   -no-phonon \
+   -no-phonon-backend \
+   -no-svg \
+   -no-webkit \
+   -no-javascript-jit \
+   -no-script \
+   -no-scripttools \
+   -no-declarative \
+   -no-gif \
+   -no-libtiff \
+   -no-libmng \
+   -no-openssl \
+   -no-nis \
+   -no-cups \
+   -no-dbus \
+   -no-opengl \
+   -no-openvg \
+   -nomake demos \
+   -nomake examples \
+   -no-gtkstyle && \
+  make -j$(grep -c processor /proc/cpuinfo) && \
+  make install && \
+  find . -name '*.o' -delete
+
+RUN git clone https://github.com/commontk/AppLauncher.git
+RUN mkdir /usr/src/AppLauncher-build
+WORKDIR /usr/src/AppLauncher-build
+RUN cmake \
+    -DCMAKE_BUILD_TYPE:STRING=Release \
+    -DBUILD_TESTING:BOOL=ON \
+    -DQT_QMAKE_EXECUTABLE:FILEPATH=/usr/src/qt-everywhere-opensource-release-build-4.8.6/bin/qmake \
+      /usr/src/AppLauncher && \
+  make -j$(grep -c processor /proc/cpuinfo) && \
+  make package

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,8 @@ RUN wget http://packages.kitware.com/download/item/6175/qt-everywhere-opensource
   find . -name '*.o' -delete
 
 RUN git clone https://github.com/commontk/AppLauncher.git
+VOLUME /usr/src/AppLauncher
+
 RUN mkdir /usr/src/AppLauncher-build
 WORKDIR /usr/src/AppLauncher-build
 RUN cmake \
@@ -74,3 +76,4 @@ RUN cmake \
       /usr/src/AppLauncher && \
   make -j$(grep -c processor /proc/cpuinfo) && \
   make package
+VOLUME /usr/src/AppLauncher-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,11 +69,6 @@ VOLUME /usr/src/AppLauncher
 
 RUN mkdir /usr/src/AppLauncher-build
 WORKDIR /usr/src/AppLauncher-build
-RUN cmake \
-    -DCMAKE_BUILD_TYPE:STRING=Release \
-    -DBUILD_TESTING:BOOL=ON \
-    -DQT_QMAKE_EXECUTABLE:FILEPATH=/usr/src/qt-everywhere-opensource-release-build-4.8.6/bin/qmake \
-      /usr/src/AppLauncher && \
-  make -j$(grep -c processor /proc/cpuinfo) && \
-  make package
+ADD docker-build-package.sh /usr/bin/build-package.sh
+RUN /usr/bin/build-package.sh
 VOLUME /usr/src/AppLauncher-build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 CTKAppLauncher
 ==============
 
+[![Circle CI](https://circleci.com/gh/commontk/AppLauncher.svg?style=svg)](https://circleci.com/gh/commontk/AppLauncher)
+
 Overview
 --------
 

--- a/Testing/CMake/ConfiguredAppLauncher-ConfigurationContents.cmake
+++ b/Testing/CMake/ConfiguredAppLauncher-ConfigurationContents.cmake
@@ -4,8 +4,10 @@ include(${TEST_BINARY_DIR}/ConfiguredAppLauncherTestPrerequisites.cmake)
 # Helper function
 function(compare_files ACTUAL EXPECTED)
   file(READ ${ACTUAL} actual)
+  string(STRIP "${actual}" actual)
   file(READ ${EXPECTED} expected)
   string(CONFIGURE "${expected}" expected @ONLY)
+  string(STRIP "${expected}" expected)
   if(NOT "${actual}" STREQUAL "${expected}")
     message(FATAL_ERROR "Content validation of '${ACTUAL}' failed:
 

--- a/Testing/Docker/Dockerfile
+++ b/Testing/Docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM thewtex/opengl:v0.1.0
+MAINTAINER CommonTK Community <ctk-developers@commontk.org>
+# Test the CTK App Launcher
+# Graphic rendering support is required, so we use a base image that support
+# rendering.
+
+# Build the same version of CMake that is in thewtex/centos-build
+WORKDIR /usr/src
+RUN git clone git://cmake.org/cmake.git CMake && \
+  cd CMake && \
+  git checkout v3.4.1 && \
+  mkdir /usr/src/CMake-build && \
+  cd /usr/src/CMake-build && \
+  /usr/src/CMake/bootstrap \
+    --parallel=$(grep -c processor /proc/cpuinfo) \
+    --prefix=/usr && \
+  make -j$(grep -c processor /proc/cpuinfo) && \
+  ./bin/cmake \
+    -DCMAKE_BUILD_TYPE:STRING=Release \
+    -DCMAKE_USE_OPENSSL:BOOL=ON . && \
+  make install && \
+  cd .. && rm -rf CMake*
+
+ENV APP "sudo chown -R user.user /usr/src/AppLauncher-build && cd /usr/src/AppLauncher-build && ctest -V"

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,25 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker info
+    - docker pull commontk/applauncher
+    - docker pull commontk/applauncher-test
+
+test:
+  override:
+    - docker build -t commontk/applauncher ~/AppLauncher/
+    - docker build -t commontk/applauncher-test ~/AppLauncher/Testing/Docker/
+    - mkdir ~/AppLauncher-build && docker run --name applauncher -v ~/AppLauncher:/usr/src/AppLauncher:ro -v ~/AppLauncher-build:/usr/src/AppLauncher-build:rw commontk/applauncher build-package.sh
+    - cp ~/AppLauncher-build/CTKAppLauncher-*.tar.gz ~/ && gunzip ~/CTKAppLauncher-*.tar.gz && mv ~/CTKAppLauncher-*.tar $CIRCLE_ARTIFACTS/CTKAppLauncher-linux-amd64.tar.gz
+    - docker run --name applauncher-test --volumes-from applauncher commontk/applauncher-test; docker cp applauncher-test:/var/log/supervisor/graphical-app-launcher.log - | tar xO; [ "$(docker cp applauncher-test:/tmp/graphical-app.return_code - | tar xO)" = 0 ]
+
+deployment:
+  hub:
+    branch: master
+    commands:
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - docker push commontk/applauncher
+      - docker push commontk/applauncher-test

--- a/docker-build-package.sh
+++ b/docker-build-package.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+cd /usr/src/AppLauncher-build
+rm -rf *
+
+cmake \
+  -DCMAKE_BUILD_TYPE:STRING=Release \
+  -DBUILD_TESTING:BOOL=ON \
+  -DQT_QMAKE_EXECUTABLE:FILEPATH=/usr/src/qt-everywhere-opensource-release-build-4.8.6/bin/qmake \
+    /usr/src/AppLauncher || exit 1
+make -j$(grep -c processor /proc/cpuinfo) || exit 1
+make package || exit 1


### PR DESCRIPTION
This pull request adds support for building, packaging, and testing the AppLauncher on Linux. This has multiple advantages.

- The package is built on an old version of CentOS, which has a glibc version that makes the binaries generated compatible with most Linux distributions.
- The CentOS Docker build image also has a newer version of the compiler, which generates better optimized binaries.
- The build steps are explicit and reproducible.
- The test suite can be automatically run on pull requests.
- A new package is automatically generate and is easily accessible after every merge.

This topic branch
- Adds a Dockerfile to build and package the repository.
- Adds a Dockerfile for an image with graphical support to run the test suite.
- Fixes the test suite to be compatible with the latest CMake (3.4.1).
- Adds CircleCI continuous integration configuration to test pull requests and generate a package artifact that can be downloaded.
- Adds a CircleCI status badge.

Before merging this pull request, testing for the repository should be enabled at circleci.com. Also in the CircleCI configuration for the project, DOCKER_EMAIL, DOCKER_USER, and DOCKER_PASS environmental variables should be defined for a user in the "commontk" DockerHub organization, which I created.  @jcfr was also added as an owner for that group.

After integration, the package can be downloaded via the "Artifacts" tab of a CircleCI build. The package will need to be renamed and repacked due to the way CircleCI automatically gzips its artifacts.

CC: @jcfr 