### PR TITLE
Workaround current 'docker cp' permission denied issue on CircleCI.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,8 @@
 machine:
+  pre:
+    - echo 'DOCKER_OPTS="-s btrfs -e lxc -D --userland-proxy=false"' | sudo tee -a /etc/default/docker
+    - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.0-circleci-cp-workaround'
+    - sudo chmod 0755 /usr/bin/docker
   services:
     - docker
 


### PR DESCRIPTION
The use of 'docker cp' in the tests on CircleCI recently failed with
permission denied errors.  This was due to a LXC security upgrade on CircleCI.
The workaround is to use a patched version of Docker.

See:

  https://discuss.circleci.com/t/unable-to-use-docker-cp-but-it-worked-2-days-ago/1137/6