### PR TITLE
fix(cli): correctly parse multi-value arguments by stopping at next known argument

### DIFF
--- a/Base/ctkCommandLineParser.cpp
+++ b/Base/ctkCommandLineParser.cpp
@@ -451,8 +451,10 @@ QHash<QString, QVariant> ctkCommandLineParser::parseArguments(const QStringList&
           {
             qDebug() << "  Processing parameter" << j << ", value:" << parameter;
           }
-          if (this->argumentAdded(parameter))
+          if (this->Internal->argumentDescription(parameter) != 0)
           {
+            // we've found a known argument, it means there are no more
+            // parameter for the current argument
             this->Internal->ErrorString =
                 missingParameterError.arg(argument).arg(j-1).arg(numberOfParametersToProcess);
             if (this->Internal->Debug) { qDebug() << this->Internal->ErrorString; }
@@ -482,12 +484,15 @@ QHash<QString, QVariant> ctkCommandLineParser::parseArguments(const QStringList&
         int j = 1;
         while(j + i < arguments.size())
         {
-          if (this->argumentAdded(arguments.at(j + i)))
+          if (this->Internal->argumentDescription(arguments.at(j + i)) != 0)
           {
+            // we've found a known argument, it means there are no more
+            // parameter for the current argument
             if (this->Internal->Debug)
             {
               qDebug() << "  No more parameter for" << argument;
             }
+            j--; // this parameter does not belong to current argument
             break;
           }
           QString parameter = arguments.at(j + i);


### PR DESCRIPTION
Backport commontk/CTK@5314b9cbb (`BUG: Fixed multi-value argument parsing`, 2017-04-25) integrated into upstream CTK through the following pull request:
* https://github.com/commontk/CTK/pull/710

---

When a multi-value argument was passed to the command-line parser, all subsequent parameters were considered part of the argument.

The root cause of the problem was that the check that compared a parameter to a known argument was incorrect: the parameter name
contained the prefix (--argname) and this string was searched among argument names (such as argname).

Fixed by parsing each parameter after a multi-value argument. If a known argument is found, it is not added to the multi-value argument.