### PR TITLE
Add option CTKAppLauncher_VISIBILITY_HIDDEN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,12 @@ endif()
 #-----------------------------------------------------------------------------
 # Set symbol visibility Flags
 #
-ctkFunctionGetCompilerVisibilityFlags(VISIBILITY_CXX_FLAGS)
+
+option(CTKAppLauncher_VISIBILITY_HIDDEN "Whether to add compile flags to hide symbols of functions including inlines ones" ON)
+set(VISIBILITY_CXX_FLAGS)
+if(CTKAppLauncher_VISIBILITY_HIDDEN)
+  ctkFunctionGetCompilerVisibilityFlags(VISIBILITY_CXX_FLAGS)
+endif()
 
 #-----------------------------------------------------------------------------
 # Set C/CXX Flags


### PR DESCRIPTION
This commit adds support to exclude use of -fvisibility=hidden and
-fvisibility-inlines-hidden flags.

This allows to address "different visibility" warnings reported in [1]

[1] https://github.com/Slicer/Slicer/pull/727#issuecomment-303908680