### PR TITLE
CTKAppLauncherLibConfig: Do not force use of Qt4 imported targets

### DIFF
--- a/CMake/CTKAppLauncherLibConfig.cmake.in
+++ b/CMake/CTKAppLauncherLibConfig.cmake.in
@@ -15,7 +15,6 @@ set(CTKAppLauncherLib_QT_VERSION "@CTKAppLauncherLib_QT_VERSION_CONFIG@")
 if(CTKAppLauncherLib_QT_VERSION VERSION_GREATER "4")
   set(qt_components "Widgets")
 else()
-  set(QT_USE_IMPORTED_TARGETS 1)
   set(qt_components "QtGui")
 endif()
 


### PR DESCRIPTION
Since on MacOSX not all modules are available as "framework" (e.g libQtUiTools.a),
the assumption made in "FindQt4.cmake" is not always valid and systematically
setting QT_USE_IMPORTED_TARGETS to 1 will cause build error.

Indeed, it turns out that FindQt4.cmake expects all libraries to be
available as framework if at least "QtCore.framework" is available but this
is not true for QtUiTools.