### PR TITLE
COMP: Fix deprecation warning C4996

### DIFF
--- a/Base/ctkAppLauncherEnvironment.cpp
+++ b/Base/ctkAppLauncherEnvironment.cpp
@@ -102,9 +102,17 @@ QProcessEnvironment ctkAppLauncherEnvironment::environment(int requestedLevel)
 
   // Remove variables that are present in current environment but not
   // associated with the requested saved level.
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  QSet<QString> variablesToRemove =
+      QSet<QString> (ctkAppLauncherEnvironment::excludeReservedVariableNames(currentEnvKeys).begin(),
+          ctkAppLauncherEnvironment::excludeReservedVariableNames(currentEnvKeys).end())
+      - QSet<QString> (ctkAppLauncherEnvironment::excludeReservedVariableNames(requestedEnvKeys).begin(),
+                          ctkAppLauncherEnvironment::excludeReservedVariableNames(requestedEnvKeys).end());
+#else
   QSet<QString> variablesToRemove =
       ctkAppLauncherEnvironment::excludeReservedVariableNames(currentEnvKeys).toSet()
       - ctkAppLauncherEnvironment::excludeReservedVariableNames(requestedEnvKeys).toSet();
+#endif
   foreach(const QString& varname, variablesToRemove.values())
     {
     env.remove(varname);
@@ -150,7 +158,11 @@ void ctkAppLauncherEnvironment::updateCurrentEnvironment(const QProcessEnvironme
   QStringList curKeys = Self::envKeys(curEnv);
 
   // Unset variables not found in the provided environment
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  QStringList variablesToUnset = (QSet<QString> (curKeys.begin(), curKeys.end()) - QSet<QString> (envKeys.begin(), envKeys.end())).values();
+#else
   QStringList variablesToUnset = (curKeys.toSet() - envKeys.toSet()).toList();
+#endif
   foreach(const QString& varName, variablesToUnset)
     {
 #if defined(Q_OS_WIN32)

--- a/Base/ctkAppLauncherSettings.cpp
+++ b/Base/ctkAppLauncherSettings.cpp
@@ -5,6 +5,7 @@
 #include <QHash>
 #include <QFile>
 #include <QFileInfo>
+#include <QSet>
 #include <QSettings>
 
 // CTK includes
@@ -243,12 +244,24 @@ void ctkAppLauncherSettingsPrivate::readPathSettings(QSettings& settings, const 
     {
     if (!excludeGroups.contains("General"))
       {
-      this->AdditionalPathVariables.unite(settings.value("additionalPathVariables").toStringList().toSet()); // XXX Deprecated
+      #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+      QStringList additionalPathVariablesList = settings.value("additionalPathVariables").toStringList();
+      QSet<QString> additionalPathVariablesSet = QSet<QString> (additionalPathVariablesList.begin(), additionalPathVariablesList.end());
+      #else
+      QSet<QString> additionalPathVariablesSet = settings.value("additionalPathVariables").toStringList().toSet();
+      #endif
+      this->AdditionalPathVariables.unite(additionalPathVariablesSet); // XXX Deprecated
       }
     if (!excludeGroups.contains("Environment"))
       {
       settings.beginGroup("Environment");
-      this->AdditionalPathVariables.unite(settings.value("additionalPathVariables").toStringList().toSet());
+      #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+      QStringList additionalPathVariablesList = settings.value("additionalPathVariables").toStringList();
+      QSet<QString> additionalPathVariablesSet = QSet<QString> (additionalPathVariablesList.begin(), additionalPathVariablesList.end());
+      #else
+      QSet<QString> additionalPathVariablesSet = settings.value("additionalPathVariables").toStringList().toSet();
+      #endif
+      this->AdditionalPathVariables.unite(additionalPathVariablesSet);
       settings.endGroup();
       }
 


### PR DESCRIPTION
This PR fixes some C4996 deprecation warnings.
cc: @jcfr 

```
warning C4996: 'fileno': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _fileno. See online help for details.

warning C4996: 'QList<QString>::toSet': Use QSet<T>(list.begin(), list.end()) instead.

warning C4996: 'QString::SkipEmptyParts': was declared deprecated

warning C4996: 'QString::split': Use Qt::SplitBehavior variant instead

warning C4996: 'QSet<T>::toList': Use values() instead.
```