### PR TITLE
ENH: Allow user settings file to be in <APPLAUNCHER_DIR>

### DIFF
--- a/Base/ctkAppLauncher.cpp
+++ b/Base/ctkAppLauncher.cpp
@@ -529,7 +529,28 @@ void ctkAppLauncherPrivate::buildEnvironment(QProcessEnvironment &env)
   QHash<QString, QStringList> pathsEnvVars = q->pathsEnvVars();
   foreach(const QString& key, pathsEnvVars.keys())
     {
-    QString value = pathsEnvVars[key].join(this->PathSep);
+    // Relative paths are resolved against the launcher directory.
+    QStringList absolutePaths;
+    const QStringList& paths = pathsEnvVars[key];
+    foreach(const QString& path, paths)
+      {
+      if (path.isEmpty())
+        {
+        continue;
+        }
+      QFileInfo fileInfo(path);
+      if (fileInfo.isRelative())
+        {
+        // make absolute path by appending to SlicerHome
+        absolutePaths << QDir(q->launcherDir()).filePath(path);
+        }
+      else
+        {
+        // already absolute path
+        absolutePaths << path;
+        } 
+      }
+    QString value = absolutePaths.join(this->PathSep);
     this->reportInfo(QString("Setting env. variable [%1]:%2").arg(key, value));
     if (env.contains(key))
       {
@@ -1101,7 +1122,7 @@ int ctkAppLauncher::processArguments()
         QString("SettingsDir [%1]").arg(this->launcherSettingsDir()));
 
     d->reportInfo(
-        QString("UserAdditionalSettingsDir [%1]").arg(d->userAdditionalSettingsDir()));
+        QString("UserAdditionalSettingsDir [%1]").arg(this->userAdditionalSettingsDir()));
 
     d->reportInfo(
         QString("UserAdditionalSettingsFileName [%1]").arg(this->findUserAdditionalSettings()));

--- a/Base/ctkAppLauncher.h
+++ b/Base/ctkAppLauncher.h
@@ -23,7 +23,8 @@ class ctkAppLauncherPrivate;
 /// The ctkAppLauncher can be configured using setting files and/or command
 /// line arguments. It relies on ctkAppLauncherSettings to parse settings file
 /// and define the particular environment to set before executing
-/// the selected application.
+/// the selected application. Relative paths are resolved using the launcher
+/// directory as the base.
 ///
 /// Command line arguments
 /// ----------------------

--- a/Base/ctkAppLauncherSettings.cpp
+++ b/Base/ctkAppLauncherSettings.cpp
@@ -675,7 +675,7 @@ QString ctkAppLauncherSettings::pathVariableName() const
 // --------------------------------------------------------------------------
 QString ctkAppLauncherSettings::organizationDir()const
 {
-  // Logic for deciding between using organizatioDoman or organizationName is
+  // Logic for deciding between using organizationDoman or organizationName is
   // adopted from qtbase\src\corelib\io\qsettings.cpp.
   QString dir =
 #ifdef Q_OS_DARWIN

--- a/Base/ctkAppLauncherSettings.cpp
+++ b/Base/ctkAppLauncherSettings.cpp
@@ -70,22 +70,10 @@ QString ctkAppLauncherSettingsPrivate::findUserAdditionalSettings()const
 
   QStringList candidateUserAdditionalSettingsDirs;
 
-  // Settings stored in launcher/organization folder
-  // (logic for deciding between using organizatioDoman or organizationName is
-  // adopted from qtbase\src\corelib\io\qsettings.cpp)
-  QString organizationDir =
-  #ifdef Q_OS_DARWIN
-    QCoreApplication::organizationDomain().isEmpty()
-      ? QCoreApplication::organizationName()
-      : QCoreApplication::organizationDomain();
-  #else
-    QCoreApplication::organizationName().isEmpty()
-      ? QCoreApplication::organizationDomain()
-      : QCoreApplication::organizationName();
-  #endif
-  candidateUserAdditionalSettingsDirs << QDir(q->launcherDir()).filePath(organizationDir);
+  // Settings may be stored in launcherDir/organizationDir:
+  candidateUserAdditionalSettingsDirs << QDir(q->launcherDir()).filePath(q->organizationDir());
 
-  // Settings stored in user profile folder
+  // Settings may be stored in path/to/settings/organizationDir:
   QFileInfo fileInfo(QSettings().fileName());
   candidateUserAdditionalSettingsDirs << fileInfo.path();
 
@@ -682,4 +670,22 @@ QString ctkAppLauncherSettings::pathVariableName() const
 {
   Q_D(const ctkAppLauncherSettings);
   return d->PathVariableName;
+}
+
+// --------------------------------------------------------------------------
+QString ctkAppLauncherSettings::organizationDir()const
+{
+  // Logic for deciding between using organizatioDoman or organizationName is
+  // adopted from qtbase\src\corelib\io\qsettings.cpp.
+  QString dir =
+#ifdef Q_OS_DARWIN
+    QCoreApplication::organizationDomain().isEmpty()
+    ? QCoreApplication::organizationName()
+    : QCoreApplication::organizationDomain();
+#else
+    QCoreApplication::organizationName().isEmpty()
+    ? QCoreApplication::organizationDomain()
+    : QCoreApplication::organizationName();
+#endif
+  return dir;
 }

--- a/Base/ctkAppLauncherSettings.h
+++ b/Base/ctkAppLauncherSettings.h
@@ -73,15 +73,18 @@ class ctkAppLauncherSettingsPrivate;
 ///
 /// If a group named `Application` having at least the keys `organizationDomain`,
 /// `organizationName`, `name` is found in the main setting file given to readSettings(const QString&),
-/// then an additional setting file located in the Qt user specific settings directory is automatically parsed.
+/// then an additional setting file is automatically parsed.
 ///
 /// An optional `revision` key can also be specified.
 ///
-/// Location of additional setting file:
+/// First the launcher looks for the user settings file within &lt;APPLAUNCHER_DIR&gt;:
+///
+///   <APPLAUNCHER_DIR>/<organisationName|organizationDomain>/<ApplicationName>(-<revision>).ini
+///
+/// If the file is not found there then the launcher looks for it in the Qt user specific settings directory
+/// (corresponding to \c QSettings::UserScope):
 ///
 ///   /path/to/user/settings/<organisationName|organizationDomain>/<ApplicationName>(-<revision>).ini
-///
-/// The location of the additional settings file corresponds to \c QSettings::UserScope.
 ///
 /// Settings values found in the additional settings file are merged with the
 /// one already found in the main settings. For `Paths`, `LibraryPaths` or any

--- a/Base/ctkAppLauncherSettings.h
+++ b/Base/ctkAppLauncherSettings.h
@@ -79,12 +79,12 @@ class ctkAppLauncherSettingsPrivate;
 ///
 /// First the launcher looks for the user settings file within &lt;APPLAUNCHER_DIR&gt;:
 ///
-///   <APPLAUNCHER_DIR>/<organisationName|organizationDomain>/<ApplicationName>(-<revision>).ini
+///   <APPLAUNCHER_DIR>/<organizationDir>/<ApplicationName>(-<revision>).ini
 ///
 /// If the file is not found there then the launcher looks for it in the Qt user specific settings directory
 /// (corresponding to \c QSettings::UserScope):
 ///
-///   /path/to/user/settings/<organisationName|organizationDomain>/<ApplicationName>(-<revision>).ini
+///   /path/to/user/settings/<organizationDir>/<ApplicationName>(-<revision>).ini
 ///
 /// Settings values found in the additional settings file are merged with the
 /// one already found in the main settings. For `Paths`, `LibraryPaths` or any
@@ -236,27 +236,34 @@ public:
   ///
   QString libraryPathVariableName() const;
 
-  ///  \brief Get path variable name.
+  /// \brief Get path variable name.
   QString pathVariableName() const;
 
-  /// Return user specific additional settings file associated with the \c ApplicationOrganization,
-  /// \c ApplicationName and \c ApplicationRevision read from the main settings using
-  /// readSettings(const QString&).
+  /// \brief Return location of the existing user specific additional settings file.
   ///
-  /// The location of the additional settings file is expected to match the following name
-  /// and path: \c path/to/settings/<organisationName|organizationDomain>/<ApplicationName>(-<revision>).ini
+  /// The location of the additional settings file is first looked for at path:
+  /// \c <APPLAUNCHER_DIR>/<organizationDir>/<ApplicationName>(-<revision>).ini
+  /// and if it is not found there then at path:
+  /// \c path/to/settings/<organizationDir>/<ApplicationName>(-<revision>).ini
   /// If the settings file does NOT exist, an empty string will be returned.
   ///
   /// \sa readSettings(const QString&)
   /// \sa additionalSettingsDir()
   QString findUserAdditionalSettings()const;
 
-  /// Return additional settings directory associated with the \a ApplicationOrganization
-  /// read from the main settings.
+  /// \brief Return location of user specific additional settings directory.
   ///
-  /// The location of the additional settings directory is expected to match the following
-  /// path: \c path/to/settings/<organisationName|organizationDomain>/
+  /// The directory is the location where an existing user specific additional settings file
+  /// is found using findUserAdditionalSettings(). If no such file is found then
+  /// default location is returned: \c path/to/settings/<organizationDir>
   QString userAdditionalSettingsDir()const;
+
+  /// \brief Get organization subdirectory name determined from organization domain
+  /// or name determined according to QSettings conventions.
+  ///
+  /// On Windows and Linux: QCoreApplication::organizationName() (if undefined then QCoreApplication::organizationDomain()).
+  /// On macOS: QCoreApplication::organizationDomain() (if undefined then QCoreApplication::organizationName()).
+  QString organizationDir()const;
 
   /// \brief Set/Get launcher directory.
   ///

--- a/Base/ctkAppLauncherSettings_p.h
+++ b/Base/ctkAppLauncherSettings_p.h
@@ -25,7 +25,6 @@ public:
   ~ctkAppLauncherSettingsPrivate(){}
   typedef ctkAppLauncherSettingsPrivate Self;
 
-  QString userAdditionalSettingsDir()const;
   QString findUserAdditionalSettings()const;
 
   /// Different type of settings files.


### PR DESCRIPTION
User settings file was always stored in the user profile directory, which made it impossible
to create completely self-contained, portable applications (which store all settings within `<APPLAUNCHER_DIR>` and subfolders).

This is addressed by looking for `UserAdditionalSettings` file at `<APPLAUNCHER_DIR>/<organisationName|organizationDomain>/<ApplicationName>(-<revision>).ini`
first and if it is found then that is used. If settings is not found there then the user's profile directory is used the same way as before.

This change is necessary for allowing portable installations of 3D Slicer (https://github.com/Slicer/Slicer/pull/5029).