### PR TITLE
BUG: fix crash calculating environment keys

### DIFF
--- a/Base/ctkAppLauncherEnvironment.cpp
+++ b/Base/ctkAppLauncherEnvironment.cpp
@@ -105,8 +105,8 @@ QProcessEnvironment ctkAppLauncherEnvironment::environment(int requestedLevel)
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QStringList currentStrings = ctkAppLauncherEnvironment::excludeReservedVariableNames(currentEnvKeys);
   QStringList requestedStrings = ctkAppLauncherEnvironment::excludeReservedVariableNames(requestedEnvKeys);
-  auto currentSet = QSet<QString> (currentStrings.begin(), currentStrings.end());
-  auto requestedSet = QSet<QString> (requestedStrings.begin(), requestedStrings.end());
+  QSet<QString> currentSet(currentStrings.begin(), currentStrings.end());
+  QSet<QString> requestedSet(requestedStrings.begin(), requestedStrings.end());
   auto variablesToRemove = currentSet - requestedSet;
 #else
   QSet<QString> variablesToRemove =

--- a/Base/ctkAppLauncherEnvironment.cpp
+++ b/Base/ctkAppLauncherEnvironment.cpp
@@ -103,11 +103,11 @@ QProcessEnvironment ctkAppLauncherEnvironment::environment(int requestedLevel)
   // Remove variables that are present in current environment but not
   // associated with the requested saved level.
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-  QSet<QString> variablesToRemove =
-      QSet<QString> (ctkAppLauncherEnvironment::excludeReservedVariableNames(currentEnvKeys).begin(),
-          ctkAppLauncherEnvironment::excludeReservedVariableNames(currentEnvKeys).end())
-      - QSet<QString> (ctkAppLauncherEnvironment::excludeReservedVariableNames(requestedEnvKeys).begin(),
-                          ctkAppLauncherEnvironment::excludeReservedVariableNames(requestedEnvKeys).end());
+  QStringList currentStrings = ctkAppLauncherEnvironment::excludeReservedVariableNames(currentEnvKeys);
+  QStringList requestedStrings = ctkAppLauncherEnvironment::excludeReservedVariableNames(requestedEnvKeys);
+  auto currentSet = QSet<QString> (currentStrings.begin(), currentStrings.end());
+  auto requestedSet = QSet<QString> (requestedStrings.begin(), requestedStrings.end());
+  auto variablesToRemove = currentSet - requestedSet;
 #else
   QSet<QString> variablesToRemove =
       ctkAppLauncherEnvironment::excludeReservedVariableNames(currentEnvKeys).toSet()


### PR DESCRIPTION
Fixes #116

Each call to `ctkAppLauncherEnvironment::excludeReservedVariableNames` returns a new `QStringList` so making a QSet from the `begin()` of one and the `end()` of the other led to the crash in the `QHash`.

Solution is to make temporary variables for the `QStringList`s so that the set is made from matching iterators variables.

Also rearranged the code a bit for readability.