### PR TITLE
BUG: Ensure relative paths are resolved when using ctkAppLauncherSettings

### DIFF
--- a/Base/Testing/Cpp/ctkAppLauncherSettingsTest.cpp
+++ b/Base/Testing/Cpp/ctkAppLauncherSettingsTest.cpp
@@ -200,17 +200,20 @@ void ctkAppLauncherSettingsTester::testReadSettings()
            "[Paths]\n"
            "1\\path=<APPLAUNCHER_SETTINGS_DIR>/regular-settings-path\n"
            "2\\path=/path/within/regular-settings\n"
-           "size=2\n"
+           "3\\path=relative-path/within/regular-settings\n"
+           "size=3\n"
            "\n"
            "[LibraryPaths]\n"
            "1\\path=<APPLAUNCHER_SETTINGS_DIR>/regular-settings-librarypath\n"
            "2\\path=/librarypath/within/regular-settings\n"
-           "size=2\n"
+           "3\\path=relative-librarypath/within/regular-settings\n"
+           "size=3\n"
            "\n"
            "[EXTRA_PATH]\n"
            "1\\path=<APPLAUNCHER_SETTINGS_DIR>/regular-settings-extrapath\n"
            "2\\path=/extrapath/within/regular-settings\n"
-           "size=2\n";
+           "3\\path=relative-extrapath/within/regular-settings\n"
+           "size=3\n";
 
     regularSettingFile.close();
   }
@@ -231,17 +234,20 @@ void ctkAppLauncherSettingsTester::testReadSettings()
            "[Paths]\n"
            "1\\path=<APPLAUNCHER_SETTINGS_DIR>/user-additional-settings-path\n"
            "2\\path=/path/within/user-additional-settings\n"
-           "size=2\n"
+           "3\\path=relative-path/within/user-additional-settings\n"
+           "size=3\n"
            "\n"
            "[LibraryPaths]\n"
            "1\\path=<APPLAUNCHER_SETTINGS_DIR>/user-additional-settings-librarypath\n"
            "2\\path=/librarypath/within/user-additional-settings\n"
-           "size=2\n"
+           "3\\path=relative-librarypath/within/user-additional-settings\n"
+           "size=3\n"
            "\n"
            "[EXTRA_PATH]\n"
            "1\\path=<APPLAUNCHER_SETTINGS_DIR>/user-additional-settings-extrapath\n"
            "2\\path=/extrapath/within/user-additional-settings\n"
-           "size=2\n";
+           "3\\path=relative-extrapath/within/user-additional-settings\n"
+           "size=3\n";
 
   }
 
@@ -258,17 +264,20 @@ void ctkAppLauncherSettingsTester::testReadSettings()
            "[Paths]\n"
            "1\\path=<APPLAUNCHER_SETTINGS_DIR>/additional-settings-path\n"
            "2\\path=/path/within/additional-settings\n"
-           "size=2\n"
+           "3\\path=relative-path/within/additional-settings\n"
+           "size=3\n"
            "\n"
            "[LibraryPaths]\n"
            "1\\path=<APPLAUNCHER_SETTINGS_DIR>/additional-settings-librarypath\n"
            "2\\path=/librarypath/within/additional-settings\n"
-           "size=2\n"
+           "3\\path=relative-librarypath/within/additional-settings\n"
+           "size=3\n"
            "\n"
            "[EXTRA_PATH]\n"
            "1\\path=<APPLAUNCHER_SETTINGS_DIR>/additional-settings-extrapath\n"
            "2\\path=/extrapath/within/additional-settings\n"
-           "size=2\n";
+           "3\\path=relative-extrapath/within/additional-settings\n"
+           "size=3\n";
 
     additionalSettingFile.close();
   }
@@ -299,25 +308,25 @@ void ctkAppLauncherSettingsTester::testReadSettings()
   QCOMPARE_QSTRINGLIST(
         appLauncherSettings.paths(),
         QStringList()
-        << additionalSettingsDir + "/additional-settings-path" << "/path/within/additional-settings"
-        << userAdditionalSettingsDir + "/user-additional-settings-path" << "/path/within/user-additional-settings"
-        << regularSettingsDir + "/regular-settings-path" << "/path/within/regular-settings"
+        << additionalSettingsDir + "/additional-settings-path" << "/path/within/additional-settings" << "/path/to/relative-path/within/additional-settings"
+        << userAdditionalSettingsDir + "/user-additional-settings-path" << "/path/within/user-additional-settings" << "/path/to/relative-path/within/user-additional-settings"
+        << regularSettingsDir + "/regular-settings-path" << "/path/within/regular-settings" << "/path/to/relative-path/within/regular-settings"
         );
 
   QCOMPARE_QSTRINGLIST(
         appLauncherSettings.libraryPaths(),
         QStringList()
-        << additionalSettingsDir + "/additional-settings-librarypath" << "/librarypath/within/additional-settings"
-        << userAdditionalSettingsDir + "/user-additional-settings-librarypath" << "/librarypath/within/user-additional-settings"
-        << regularSettingsDir + "/regular-settings-librarypath" << "/librarypath/within/regular-settings"
+        << additionalSettingsDir + "/additional-settings-librarypath" << "/librarypath/within/additional-settings" << "/path/to/relative-librarypath/within/additional-settings"
+        << userAdditionalSettingsDir + "/user-additional-settings-librarypath" << "/librarypath/within/user-additional-settings" << "/path/to/relative-librarypath/within/user-additional-settings"
+        << regularSettingsDir + "/regular-settings-librarypath" << "/librarypath/within/regular-settings" << "/path/to/relative-librarypath/within/regular-settings"
         );
 
   QCOMPARE_QSTRINGLIST(
         appLauncherSettings.pathsEnvVars().value("EXTRA_PATH"),
         QStringList()
-        << additionalSettingsDir + "/additional-settings-extrapath" << "/extrapath/within/additional-settings"
-        << userAdditionalSettingsDir + "/user-additional-settings-extrapath" << "/extrapath/within/user-additional-settings"
-        << regularSettingsDir + "/regular-settings-extrapath" << "/extrapath/within/regular-settings"
+        << additionalSettingsDir + "/additional-settings-extrapath" << "/extrapath/within/additional-settings" << "/path/to/relative-extrapath/within/additional-settings"
+        << userAdditionalSettingsDir + "/user-additional-settings-extrapath" << "/extrapath/within/user-additional-settings" << "/path/to/relative-extrapath/within/user-additional-settings"
+        << regularSettingsDir + "/regular-settings-extrapath" << "/extrapath/within/regular-settings" << "/path/to/relative-extrapath/within/regular-settings"
         );
 }
 

--- a/Base/Testing/Cpp/ctkAppLauncherTestingHelper.cpp
+++ b/Base/Testing/Cpp/ctkAppLauncherTestingHelper.cpp
@@ -55,6 +55,9 @@ bool CheckStringList(int line, const QString& description,
                  << "\nCompared lists differ at index " << idx
                  << "\n\tcurrent[" << idx << "] :" << sortedCurrent.at(idx)
                  << "\n\texpected[" << idx << "]:" << sortedExpected.at(idx);
+      qWarning().nospace()
+                 << "\n\tcurrent list values:\n\t\t" << sortedCurrent.join("\n\t\t")
+                 << "\n\texpected list values:\n\t\t" << sortedExpected.join("\n\t\t");
       return false;
       }
     }

--- a/Base/ctkAppLauncher.cpp
+++ b/Base/ctkAppLauncher.cpp
@@ -529,28 +529,8 @@ void ctkAppLauncherPrivate::buildEnvironment(QProcessEnvironment &env)
   QHash<QString, QStringList> pathsEnvVars = q->pathsEnvVars();
   foreach(const QString& key, pathsEnvVars.keys())
     {
-    // Relative paths are resolved against the launcher directory.
-    QStringList absolutePaths;
     const QStringList& paths = pathsEnvVars[key];
-    foreach(const QString& path, paths)
-      {
-      if (path.isEmpty())
-        {
-        continue;
-        }
-      QFileInfo fileInfo(path);
-      if (fileInfo.isRelative())
-        {
-        // make absolute path by appending to SlicerHome
-        absolutePaths << QDir(q->launcherDir()).filePath(path);
-        }
-      else
-        {
-        // already absolute path
-        absolutePaths << path;
-        } 
-      }
-    QString value = absolutePaths.join(this->PathSep);
+    QString value = paths.join(this->PathSep);
     this->reportInfo(QString("Setting env. variable [%1]:%2").arg(key, value));
     if (env.contains(key))
       {

--- a/Base/ctkAppLauncherSettings.cpp
+++ b/Base/ctkAppLauncherSettings.cpp
@@ -293,6 +293,20 @@ void ctkAppLauncherSettingsPrivate::readPathSettings(QSettings& settings, const 
 }
 
 // --------------------------------------------------------------------------
+QString ctkAppLauncherSettingsPrivate::resolvePath(const QString& path) const
+{
+  QFileInfo fileInfo(path);
+  if (!this->LauncherDir.isEmpty() && fileInfo.isRelative())
+    {
+    return QDir(this->LauncherDir).filePath(path);
+    }
+  else
+    {
+    return path;
+    }
+}
+
+// --------------------------------------------------------------------------
 QString ctkAppLauncherSettingsPrivate::expandValue(const QString& value) const
 {
   QString updatedValue = this->expandPlaceHolders(value);
@@ -567,7 +581,7 @@ QStringList ctkAppLauncherSettings::libraryPaths(bool expand /* = true */)const
   QStringList expanded;
   foreach(const QString& path, d->ListOfLibraryPaths)
     {
-    expanded << (expand ? d->expandValue(path) : path);
+    expanded << (expand ? d->resolvePath(d->expandValue(path)) : path);
     }
   return expanded;
 }
@@ -579,7 +593,7 @@ QStringList ctkAppLauncherSettings::paths(bool expand /* = true */)const
   QStringList expanded;
   foreach(const QString& path, d->ListOfPaths)
     {
-    expanded << (expand ? d->expandValue(path) : path);
+    expanded << (expand ? d->resolvePath(d->expandValue(path)) : path);
     }
   return expanded;
 }
@@ -634,7 +648,7 @@ QStringList ctkAppLauncherSettings::additionalPaths(const QString& variableName,
   QStringList expanded;
   foreach(const QString& path, d->MapOfPathVars.value(variableName))
     {
-    expanded << (expand ? d->expandValue(path) : path);
+    expanded << (expand ? d->resolvePath(d->expandValue(path)) : path);
     }
   return expanded;
 }

--- a/Base/ctkAppLauncherSettings.h
+++ b/Base/ctkAppLauncherSettings.h
@@ -169,27 +169,33 @@ public:
 
   /// Get list of paths associated with the \c Paths group.
   ///
-  /// By default, placeholder strings are expanded.
+  /// By default, placeholder strings are expanded and relative paths are updated
+  /// prepending the launcher directory.
   ///
   /// \sa ctkAppLauncherSettingsPrivate::expandValue(const QString& value)
+  /// \sa launcherDir()
   QStringList paths(bool expand = true)const;
 
   /// Get environment variable value associated with \c EnvironmentVariables
   /// group.
   ///
-  /// By default, placeholder strings are expanded.
+  /// By default, placeholder strings are expanded and relative paths are updated
+  /// prepending the launcher directory.
   ///
   /// \sa envVars(bool expand)
   /// \sa ctkAppLauncherSettingsPrivate::expandValue(const QString& value)
+  /// \sa launcherDir()
   QString envVar(const QString& variableName, bool expand = true) const;
 
   /// Get list of environment variables associated with \c EnvironmentVariables
   /// group.
   ///
-  /// By default, placeholder strings are expanded.
+  /// By default, placeholder strings are expanded and relative paths are updated
+  /// prepending the launcher directory.
   ///
   /// \sa envVar(const QString& variableName, bool expand)
   /// \sa ctkAppLauncherSettingsPrivate::expandValue(const QString& value)
+  /// \sa launcherDir()
   QHash<QString, QString> envVars(bool expand = true) const;
 
   /// \brief Get dictionnary of all list of paths.
@@ -211,9 +217,11 @@ public:
   /// `DYLD_LIBRARY_PATH`   | NA              | libraryPaths()  | NA                       |
   /// `PATH`                | paths()         | paths()         | paths() + libraryPaths() |
   ///
-  /// By default, placeholder strings are expanded.
+  /// By default, placeholder strings are expanded and relative paths are updated
+  /// prepending the launcher directory.
   ///
   /// \sa ctkAppLauncherSettingsPrivate::expandValue(const QString& value)
+  /// \sa launcherDir()
   /// \sa additionalPathsVars(bool expand)
   /// \sa libraryPaths(bool expand)
   /// \sa paths(bool expand)
@@ -226,17 +234,21 @@ public:
   /// The returned list corresponds to the path list identified by one of
   /// the variable associated with \c General/additionalPathVariables.
   ///
-  /// By default, placeholder strings are expanded.
+  /// By default, placeholder strings are expanded and relative paths are updated
+  /// prepending the launcher directory.
   ///
   /// \sa ctkAppLauncherSettingsPrivate::expandValue(const QString& value)
+  /// \sa launcherDir()
   QStringList additionalPaths(const QString& variableName, bool expand = true) const;
 
   /// \brief Get dictionnary of path list associated with \c General/additionalPathVariables.
   ///
-  /// By default, placeholder strings are expanded.
+  /// By default, placeholder strings are expanded and relative paths are updated
+  /// prepending the launcher directory.
   ///
   /// \sa additionalPaths(const QString& variableName, bool expand)
   /// \sa ctkAppLauncherSettingsPrivate::expandValue(const QString& value)
+  /// \sa launcherDir()
   QHash<QString, QStringList> additionalPathsVars(bool expand = true) const;
 
   /// \brief Get current platform path separator.

--- a/Base/ctkAppLauncherSettings.h
+++ b/Base/ctkAppLauncherSettings.h
@@ -163,21 +163,33 @@ public:
   void setAdditionalSettingsExcludeGroups(const QStringList& excludeGroups);
 
   /// Get list of library paths associated with the \c LibraryPaths group.
+  ///
+  /// \sa ctkAppLauncherSettingsPrivate::expandValue(const QString& value)
   QStringList libraryPaths(bool expand = true)const;
 
   /// Get list of paths associated with the \c Paths group.
+  ///
+  /// By default, placeholder strings are expanded.
+  ///
+  /// \sa ctkAppLauncherSettingsPrivate::expandValue(const QString& value)
   QStringList paths(bool expand = true)const;
 
   /// Get environment variable value associated with \c EnvironmentVariables
   /// group.
   ///
-  /// \sa envVars(bool)
+  /// By default, placeholder strings are expanded.
+  ///
+  /// \sa envVars(bool expand)
+  /// \sa ctkAppLauncherSettingsPrivate::expandValue(const QString& value)
   QString envVar(const QString& variableName, bool expand = true) const;
 
   /// Get list of environment variables associated with \c EnvironmentVariables
   /// group.
   ///
+  /// By default, placeholder strings are expanded.
+  ///
   /// \sa envVar(const QString& variableName, bool expand)
+  /// \sa ctkAppLauncherSettingsPrivate::expandValue(const QString& value)
   QHash<QString, QString> envVars(bool expand = true) const;
 
   /// \brief Get dictionnary of all list of paths.
@@ -199,6 +211,9 @@ public:
   /// `DYLD_LIBRARY_PATH`   | NA              | libraryPaths()  | NA                       |
   /// `PATH`                | paths()         | paths()         | paths() + libraryPaths() |
   ///
+  /// By default, placeholder strings are expanded.
+  ///
+  /// \sa ctkAppLauncherSettingsPrivate::expandValue(const QString& value)
   /// \sa additionalPathsVars(bool expand)
   /// \sa libraryPaths(bool expand)
   /// \sa paths(bool expand)
@@ -210,11 +225,18 @@ public:
   ///
   /// The returned list corresponds to the path list identified by one of
   /// the variable associated with \c General/additionalPathVariables.
+  ///
+  /// By default, placeholder strings are expanded.
+  ///
+  /// \sa ctkAppLauncherSettingsPrivate::expandValue(const QString& value)
   QStringList additionalPaths(const QString& variableName, bool expand = true) const;
 
   /// \brief Get dictionnary of path list associated with \c General/additionalPathVariables.
   ///
+  /// By default, placeholder strings are expanded.
+  ///
   /// \sa additionalPaths(const QString& variableName, bool expand)
+  /// \sa ctkAppLauncherSettingsPrivate::expandValue(const QString& value)
   QHash<QString, QStringList> additionalPathsVars(bool expand = true) const;
 
   /// \brief Get current platform path separator.

--- a/Base/ctkAppLauncherSettings_p.h
+++ b/Base/ctkAppLauncherSettings_p.h
@@ -40,6 +40,11 @@ public:
   static QString updateSettingDirPlaceHolder(const QString& value, const SettingsType& settingsType);
   static QStringList updateSettingDirPlaceHolder(const QStringList& values, const SettingsType& settingsType);
 
+  /// \brief Relative path is resolved against the launcher directory.
+  ///
+  /// If the launcher directory is empty, returns \a path.
+  QString resolvePath(const QString& path) const;
+
   /// \brief Expand setting \a value
   ///
   /// The following placeholder strings will be updated:

--- a/Testing/LauncherLib/AppWithLauncherLib/launcher-settings.ini
+++ b/Testing/LauncherLib/AppWithLauncherLib/launcher-settings.ini
@@ -12,14 +12,16 @@ organizationName=Kitware
 2\path=<APPLAUNCHER_DIR>/libB
 3\path=/path/to/libC-<env:PET>
 4\path=<APPLAUNCHER_SETTINGS_DIR>/libC
-size=4
+5\path=relative-path/libC
+size=5
 
 [Paths]
 1\path=<APPLAUNCHER_DIR>/cow/<APPLAUNCHER_NAME>
 2\path=/path/to/pig-<env:BOTH>
 3\path=/path/to/<env:PET>
 4\path=<APPLAUNCHER_SETTINGS_DIR>/sheep/<APPLAUNCHER_NAME>
-size=4
+5\path=relative-path/sheep/<APPLAUNCHER_NAME>
+size=5
 
 [EnvironmentVariables]
 BAR=ASSOCIATION
@@ -32,10 +34,12 @@ SETTINGSPLACEHOLDER=<APPLAUNCHER_SETTINGS_DIR>-<APPLAUNCHER_NAME>
 1\path=<APPLAUNCHER_DIR>/lib/python/site-packages
 2\path=/path/to/site-packages-2
 3\path=<APPLAUNCHER_SETTINGS_DIR>/lib/python/site-packages-settings
-size=3
+4\path=relative-path/to/site-packages-3
+size=4
 
 [QT_PLUGIN_PATH]
 1\path=<APPLAUNCHER_DIR>/libexec/qt
 2\path=<APPLAUNCHER_DIR>/libexec/<env:BAR>
 3\path=<APPLAUNCHER_SETTINGS_DIR>/libexec-settings/<env:BAR>
-size=3
+4\path=relative-path/libexec-settings/<env:BAR>
+size=4

--- a/Testing/LauncherLib/AppWithLauncherLib/launcher-user-additional-settings.ini
+++ b/Testing/LauncherLib/AppWithLauncherLib/launcher-user-additional-settings.ini
@@ -4,14 +4,16 @@
 1\path=/path/to/libD
 2\path=<APPLAUNCHER_DIR>/libE-<env:PET>
 3\path=<APPLAUNCHER_SETTINGS_DIR>/libF
-size=3
+4\path=relative-path/libF
+size=4
 
 [Paths]
 1\path=<APPLAUNCHER_DIR>/fawn
 2\path=/path/to/cat-and-<env:PET>
 3\path=/path/to/<env:PAINTER>
 4\path=<APPLAUNCHER_SETTINGS_DIR>/osprey
-size=4
+5\path=relative-path/osprey
+size=5
 
 [EnvironmentVariables]
 BAR=RAB
@@ -22,4 +24,5 @@ PAINTER=Klimt
 2\path=<APPLAUNCHER_DIR>/lib/python/site-packages-3
 3\path=/path/to/site-packages-<env:BAR>
 4\path=<APPLAUNCHER_SETTINGS_DIR>/lib/python/site-packages-settings-2
-size=4
+5\path=relative-path/lib/python/site-packages-settings-2
+size=5

--- a/Testing/LauncherLib/AppWithLauncherLib/main.cpp
+++ b/Testing/LauncherLib/AppWithLauncherLib/main.cpp
@@ -74,6 +74,7 @@ int checkReadSettingsWithoutExpand()
                 << "/path/to/pig-<env:BOTH>"
                 << "/path/to/<env:PET>"
                 << "<APPLAUNCHER_REGULAR_SETTINGS_DIR>/sheep/<APPLAUNCHER_NAME>"
+                << "relative-path/sheep/<APPLAUNCHER_NAME>"
         );
 
   CHECK_QSTRINGLIST(
@@ -83,6 +84,7 @@ int checkReadSettingsWithoutExpand()
                 << "<APPLAUNCHER_DIR>/libB"
                 << "/path/to/libC-<env:PET>"
                 << "<APPLAUNCHER_REGULAR_SETTINGS_DIR>/libC"
+                << "relative-path/libC"
         );
 
   CHECK_QSTRING(
@@ -113,22 +115,22 @@ int checkReadSettingsWithoutExpand()
 #if defined(Q_OS_WIN32)
   CHECK_QSTRING(
         appLauncherSettings.envVar("PYTHONPATH", /* expand= */ false),
-        "<APPLAUNCHER_DIR>/lib/python/site-packages;/path/to/site-packages-2;<APPLAUNCHER_REGULAR_SETTINGS_DIR>/lib/python/site-packages-settings"
+        "<APPLAUNCHER_DIR>/lib/python/site-packages;/path/to/site-packages-2;<APPLAUNCHER_REGULAR_SETTINGS_DIR>/lib/python/site-packages-settings;relative-path/to/site-packages-3"
         );
 
   CHECK_QSTRING(
         appLauncherSettings.envVar("QT_PLUGIN_PATH", /* expand= */ false),
-        "<APPLAUNCHER_DIR>/libexec/qt;<APPLAUNCHER_DIR>/libexec/<env:BAR>;<APPLAUNCHER_REGULAR_SETTINGS_DIR>/libexec-settings/<env:BAR>"
+        "<APPLAUNCHER_DIR>/libexec/qt;<APPLAUNCHER_DIR>/libexec/<env:BAR>;<APPLAUNCHER_REGULAR_SETTINGS_DIR>/libexec-settings/<env:BAR>;relative-path/libexec-settings/<env:BAR>"
         );
 #else
   CHECK_QSTRING(
         appLauncherSettings.envVar("PYTHONPATH", /* expand= */ false),
-        "<APPLAUNCHER_DIR>/lib/python/site-packages:/path/to/site-packages-2:<APPLAUNCHER_REGULAR_SETTINGS_DIR>/lib/python/site-packages-settings"
+        "<APPLAUNCHER_DIR>/lib/python/site-packages:/path/to/site-packages-2:<APPLAUNCHER_REGULAR_SETTINGS_DIR>/lib/python/site-packages-settings:relative-path/to/site-packages-3"
         );
 
   CHECK_QSTRING(
         appLauncherSettings.envVar("QT_PLUGIN_PATH", /* expand= */ false),
-        "<APPLAUNCHER_DIR>/libexec/qt:<APPLAUNCHER_DIR>/libexec/<env:BAR>:<APPLAUNCHER_REGULAR_SETTINGS_DIR>/libexec-settings/<env:BAR>"
+        "<APPLAUNCHER_DIR>/libexec/qt:<APPLAUNCHER_DIR>/libexec/<env:BAR>:<APPLAUNCHER_REGULAR_SETTINGS_DIR>/libexec-settings/<env:BAR>:relative-path/libexec-settings/<env:BAR>"
         );
 #endif
 
@@ -138,6 +140,7 @@ int checkReadSettingsWithoutExpand()
                 << "<APPLAUNCHER_DIR>/lib/python/site-packages"
                 << "/path/to/site-packages-2"
                 << "<APPLAUNCHER_REGULAR_SETTINGS_DIR>/lib/python/site-packages-settings"
+                << "relative-path/to/site-packages-3"
         );
 
   CHECK_QSTRINGLIST(
@@ -146,6 +149,7 @@ int checkReadSettingsWithoutExpand()
                 << "<APPLAUNCHER_DIR>/libexec/qt"
                 << "<APPLAUNCHER_DIR>/libexec/<env:BAR>"
                 << "<APPLAUNCHER_REGULAR_SETTINGS_DIR>/libexec-settings/<env:BAR>"
+                << "relative-path/libexec-settings/<env:BAR>"
         );
 
   //
@@ -163,10 +167,12 @@ int checkReadSettingsWithoutExpand()
                 << "/path/to/pig-<env:BOTH>"
                 << "/path/to/<env:PET>"
                 << "<APPLAUNCHER_REGULAR_SETTINGS_DIR>/sheep/<APPLAUNCHER_NAME>"
+                << "relative-path/sheep/<APPLAUNCHER_NAME>"
                 << "/path/to/libA"
                 << "<APPLAUNCHER_DIR>/libB"
                 << "/path/to/libC-<env:PET>"
                 << "<APPLAUNCHER_REGULAR_SETTINGS_DIR>/libC"
+                << "relative-path/libC"
         );
 #else
   CHECK_QSTRINGLIST(
@@ -176,6 +182,7 @@ int checkReadSettingsWithoutExpand()
                 << "/path/to/pig-<env:BOTH>"
                 << "/path/to/<env:PET>"
                 << "<APPLAUNCHER_REGULAR_SETTINGS_DIR>/sheep/<APPLAUNCHER_NAME>"
+                << "relative-path/sheep/<APPLAUNCHER_NAME>"
         );
 
   CHECK_QSTRINGLIST(
@@ -185,6 +192,7 @@ int checkReadSettingsWithoutExpand()
                 << "<APPLAUNCHER_DIR>/libB"
                 << "/path/to/libC-<env:PET>"
                 << "<APPLAUNCHER_REGULAR_SETTINGS_DIR>/libC"
+                << "relative-path/libC"
         );
 #endif
 
@@ -194,6 +202,7 @@ int checkReadSettingsWithoutExpand()
                 << "<APPLAUNCHER_DIR>/lib/python/site-packages"
                 << "/path/to/site-packages-2"
                 << "<APPLAUNCHER_REGULAR_SETTINGS_DIR>/lib/python/site-packages-settings"
+                << "relative-path/to/site-packages-3"
         );
 
   CHECK_QSTRINGLIST(
@@ -202,6 +211,7 @@ int checkReadSettingsWithoutExpand()
                 << "<APPLAUNCHER_DIR>/libexec/qt"
                 << "<APPLAUNCHER_DIR>/libexec/<env:BAR>"
                 << "<APPLAUNCHER_REGULAR_SETTINGS_DIR>/libexec-settings/<env:BAR>"
+                << "relative-path/libexec-settings/<env:BAR>"
         );
 
 #if defined(Q_OS_WIN32)
@@ -241,6 +251,7 @@ int checkReadSettingsWithExpand()
                 << "/path/to/pig-cat-and-dog"
                 << "/path/to/dog"
                 << QString("%1/sheep/AwesomeApp").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/sheep/AwesomeApp"
         );
 
   CHECK_QSTRINGLIST(
@@ -250,6 +261,7 @@ int checkReadSettingsWithExpand()
                 << "/awesome/path/to/libB"
                 << "/path/to/libC-dog"
                 << QString("%1/libC").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/libC"
         );
 
   CHECK_QSTRING(
@@ -280,22 +292,22 @@ int checkReadSettingsWithExpand()
 #if defined(Q_OS_WIN32)
   CHECK_QSTRING(
         appLauncherSettings.envVar("PYTHONPATH"),
-        QString("/awesome/path/to/lib/python/site-packages;/path/to/site-packages-2;%1/lib/python/site-packages-settings").arg(regularSettingsDir)
+        QString("/awesome/path/to/lib/python/site-packages;/path/to/site-packages-2;%1/lib/python/site-packages-settings;/awesome/path/to/relative-path/to/site-packages-3").arg(regularSettingsDir)
         );
 
   CHECK_QSTRING(
         appLauncherSettings.envVar("QT_PLUGIN_PATH"),
-        QString("/awesome/path/to/libexec/qt;/awesome/path/to/libexec/ASSOCIATION;%1/libexec-settings/ASSOCIATION").arg(regularSettingsDir)
+        QString("/awesome/path/to/libexec/qt;/awesome/path/to/libexec/ASSOCIATION;%1/libexec-settings/ASSOCIATION;/awesome/path/to/relative-path/libexec-settings/ASSOCIATION").arg(regularSettingsDir)
         );
 #else
   CHECK_QSTRING(
         appLauncherSettings.envVar("PYTHONPATH"),
-        QString("/awesome/path/to/lib/python/site-packages:/path/to/site-packages-2:%1/lib/python/site-packages-settings").arg(regularSettingsDir)
+        QString("/awesome/path/to/lib/python/site-packages:/path/to/site-packages-2:%1/lib/python/site-packages-settings:/awesome/path/to/relative-path/to/site-packages-3").arg(regularSettingsDir)
         );
 
   CHECK_QSTRING(
         appLauncherSettings.envVar("QT_PLUGIN_PATH"),
-        QString("/awesome/path/to/libexec/qt:/awesome/path/to/libexec/ASSOCIATION:%1/libexec-settings/ASSOCIATION").arg(regularSettingsDir)
+        QString("/awesome/path/to/libexec/qt:/awesome/path/to/libexec/ASSOCIATION:%1/libexec-settings/ASSOCIATION:/awesome/path/to/relative-path/libexec-settings/ASSOCIATION").arg(regularSettingsDir)
         );
 #endif
 
@@ -305,6 +317,7 @@ int checkReadSettingsWithExpand()
                 << "/awesome/path/to/lib/python/site-packages"
                 << "/path/to/site-packages-2"
                 << QString("%1/lib/python/site-packages-settings").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/to/site-packages-3"
         );
 
   CHECK_QSTRINGLIST(
@@ -313,6 +326,7 @@ int checkReadSettingsWithExpand()
                 << "/awesome/path/to/libexec/qt"
                 << "/awesome/path/to/libexec/ASSOCIATION"
                 << QString("%1/libexec-settings/ASSOCIATION").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/libexec-settings/ASSOCIATION"
         );
 
   CHECK_QSTRINGLIST(
@@ -321,6 +335,7 @@ int checkReadSettingsWithExpand()
                 << "/awesome/path/to/lib/python/site-packages"
                 << "/path/to/site-packages-2"
                 << QString("%1/lib/python/site-packages-settings").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/to/site-packages-3"
         );
 
   CHECK_QSTRINGLIST(
@@ -329,6 +344,7 @@ int checkReadSettingsWithExpand()
                 << "/awesome/path/to/libexec/qt"
                 << "/awesome/path/to/libexec/ASSOCIATION"
                 << QString("%1/libexec-settings/ASSOCIATION").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/libexec-settings/ASSOCIATION"
         );
 
   //
@@ -346,10 +362,12 @@ int checkReadSettingsWithExpand()
                 << "/path/to/pig-cat-and-dog"
                 << "/path/to/dog"
                 << QString("%1/sheep/AwesomeApp").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/sheep/AwesomeApp"
                 << "/path/to/libA"
                 << "/awesome/path/to/libB"
                 << "/path/to/libC-dog"
                 << QString("%1/libC").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/libC"
         );
 #else
   CHECK_QSTRINGLIST(
@@ -359,6 +377,7 @@ int checkReadSettingsWithExpand()
                 << "/path/to/pig-cat-and-dog"
                 << "/path/to/dog"
                 << QString("%1/sheep/AwesomeApp").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/sheep/AwesomeApp"
         );
 
   CHECK_QSTRINGLIST(
@@ -368,6 +387,7 @@ int checkReadSettingsWithExpand()
                 << "/awesome/path/to/libB"
                 << "/path/to/libC-dog"
                 << QString("%1/libC").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/libC"
         );
 #endif
 
@@ -377,6 +397,7 @@ int checkReadSettingsWithExpand()
                 << "/awesome/path/to/lib/python/site-packages"
                 << "/path/to/site-packages-2"
                 << QString("%1/lib/python/site-packages-settings").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/to/site-packages-3"
         );
 
   CHECK_QSTRINGLIST(
@@ -385,6 +406,7 @@ int checkReadSettingsWithExpand()
                 << "/awesome/path/to/libexec/qt"
                 << "/awesome/path/to/libexec/ASSOCIATION"
                 << QString("%1/libexec-settings/ASSOCIATION").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/libexec-settings/ASSOCIATION"
         );
 
 #if defined(Q_OS_WIN32)
@@ -463,10 +485,12 @@ int checkReadAdditionalSettingsWithExpand()
                 << "/path/to/cat-and-dog"
                 << "/path/to/Klimt"
                 << QString("%1/osprey").arg(userAdditionalSettingsDir)
+                << "/awesome/path/to/relative-path/osprey"
                 << QString("/awesome/path/to/cow/%1").arg(appName)
                 << "/path/to/pig-cat-and-dog"
                 << "/path/to/dog"
                 << QString("%1/sheep/%2").arg(regularSettingsDir).arg(appName)
+                << QString("/awesome/path/to/relative-path/sheep/%1").arg(appName)
         );
 
   CHECK_QSTRINGLIST(
@@ -475,10 +499,12 @@ int checkReadAdditionalSettingsWithExpand()
                 << "/path/to/libD"
                 << "/awesome/path/to/libE-dog"
                 << QString("%1/libF").arg(userAdditionalSettingsDir)
+                << "/awesome/path/to/relative-path/libF"
                 << "/path/to/libA"
                 << "/awesome/path/to/libB"
                 << "/path/to/libC-dog"
                 << QString("%1/libC").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/libC"
         );
 
   CHECK_QSTRING(
@@ -498,9 +524,11 @@ int checkReadAdditionalSettingsWithExpand()
                 << "/awesome/path/to/lib/python/site-packages-3"
                 << "/path/to/site-packages-RAB"
                 << QString("%1/lib/python/site-packages-settings-2").arg(userAdditionalSettingsDir)
+                << "/awesome/path/to/relative-path/lib/python/site-packages-settings-2"
                 << "/awesome/path/to/lib/python/site-packages"
                 << "/path/to/site-packages-2"
                 << QString("%1/lib/python/site-packages-settings").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/to/site-packages-3"
         );
 
   CHECK_QSTRINGLIST(
@@ -510,9 +538,11 @@ int checkReadAdditionalSettingsWithExpand()
                 << "/awesome/path/to/lib/python/site-packages-3"
                 << "/path/to/site-packages-RAB"
                 << QString("%1/lib/python/site-packages-settings-2").arg(userAdditionalSettingsDir)
+                << "/awesome/path/to/relative-path/lib/python/site-packages-settings-2"
                 << "/awesome/path/to/lib/python/site-packages"
                 << "/path/to/site-packages-2"
                 << QString("%1/lib/python/site-packages-settings").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/to/site-packages-3"
         );
 
   CHECK_QSTRINGLIST(
@@ -521,6 +551,7 @@ int checkReadAdditionalSettingsWithExpand()
                 << "/awesome/path/to/libexec/qt"
                 << "/awesome/path/to/libexec/RAB"
                 << QString("%1/libexec-settings/RAB").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/libexec-settings/RAB"
         );
 
   CHECK_QSTRINGLIST(
@@ -529,6 +560,7 @@ int checkReadAdditionalSettingsWithExpand()
                 << "/awesome/path/to/libexec/qt"
                 << "/awesome/path/to/libexec/RAB"
                 << QString("%1/libexec-settings/RAB").arg(regularSettingsDir)
+                << "/awesome/path/to/relative-path/libexec-settings/RAB"
         );
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
This commit is a follow up of 9931394cf (ENH: Allow user settings file
to be in <APPLAUNCHER_DIR> (#114))
    
See https://github.com/Slicer/Slicer/issues/5437