### PR TITLE
Fix passing of non-ASCII characters as command-line arguments

### DIFF
--- a/Base/Testing/Cpp/ctkAppLauncherEnvironmentTest.cpp
+++ b/Base/Testing/Cpp/ctkAppLauncherEnvironmentTest.cpp
@@ -52,14 +52,14 @@ void ctkAppLauncherEnvironmentTester::cleanup()
   QStringList originalEnvKeys = ctkAppLauncherEnvironment::envKeys(this->OriginalEnv);
   foreach(const QString& varName, originalEnvKeys)
     {
-    qputenv(varName.toLatin1(), this->OriginalEnv.value(varName).toLatin1());
+    qputenv(varName.toLocal8Bit(), this->OriginalEnv.value(varName).toLocal8Bit());
     }
 }
 
 // ----------------------------------------------------------------------------
 void ctkAppLauncherEnvironmentTester::setEnv(const QString& name, const QString& value)
 {
-  qputenv(name.toLatin1(), value.toLatin1());
+  qputenv(name.toLocal8Bit(), value.toLocal8Bit());
   this->VariableNames.insert(name);
 }
 
@@ -67,9 +67,9 @@ void ctkAppLauncherEnvironmentTester::setEnv(const QString& name, const QString&
 void ctkAppLauncherEnvironmentTester::unsetEnv(const QString& name)
 {
 #if defined(_MSC_VER)
-  qputenv(name.toLatin1(), QString("").toLatin1());
+  qputenv(name.toLocal8Bit(), QString().toLocal8Bit());
 #else
-  unsetenv(name.toLatin1());
+  unsetenv(name.toLocal8Bit());
 #endif
 }
 

--- a/Base/ctkAppArguments.cpp
+++ b/Base/ctkAppArguments.cpp
@@ -58,7 +58,7 @@ void ctkChar2DArray::setValues(const QStringList& list)
     {
     QString item = d->List.at(index);
     d->Values[index] = new char[item.size() + 1];
-    qstrcpy(d->Values[index], item.toLatin1().data());
+    qstrcpy(d->Values[index], item.toLocal8Bit().data());
     }
 }
 

--- a/Base/ctkAppLauncherEnvironment.cpp
+++ b/Base/ctkAppLauncherEnvironment.cpp
@@ -166,9 +166,9 @@ void ctkAppLauncherEnvironment::updateCurrentEnvironment(const QProcessEnvironme
   foreach(const QString& varName, variablesToUnset)
     {
 #if defined(Q_OS_WIN32)
-    bool success = qputenv(varName.toLatin1(), QString("").toLatin1());
+    bool success = qputenv(varName.toLocal8Bit(), QString().toLocal8Bit());
 #else
-    bool success = unsetenv(varName.toLatin1()) == EXIT_SUCCESS;
+    bool success = unsetenv(varName.toLocal8Bit()) == EXIT_SUCCESS;
 #endif
     if (!success)
       {
@@ -180,7 +180,7 @@ void ctkAppLauncherEnvironment::updateCurrentEnvironment(const QProcessEnvironme
   foreach(const QString& varName, envKeys)
     {
     QString varValue = environment.value(varName);
-    bool success = qputenv(varName.toLatin1(), varValue.toLatin1());
+    bool success = qputenv(varName.toLocal8Bit(), varValue.toLocal8Bit());
     if (!success)
       {
       qWarning() << "Failed to set environment variable"

--- a/Base/ctkCommandLineParser.h
+++ b/Base/ctkCommandLineParser.h
@@ -1,6 +1,10 @@
 #ifndef __ctkCommandLineParser_h
 #define __ctkCommandLineParser_h
 
+#if defined (_WIN32)
+#include <windows.h>
+#endif
+
 // Qt includes
 #include <QString>
 #include <QStringList>
@@ -383,14 +387,18 @@ public:
     */
   void setStrictModeEnabled(bool strictMode);
 
+#if defined (_WIN32)
   /**
    * Convert windows-style arguments given as a command-line string
    * into more traditional argc/argv arguments.
+   * If an argument is failed to be retrieved (for example, due to character encoding error)
+   * then the corresponding argv pointer is set to point to an empty string.
    *
    * @note argv[0] will be assigned the executable name using the ::GetModuleFileName function.
    */
   static void convertWindowsCommandLineToUnixArguments(
-    const char *cmd_line, int *argc, char ***argv);
+    PWSTR cmd_line, int* argc, char*** argv);
+#endif
 
 private:
   class ctkInternal;

--- a/Base/ctkTest.h
+++ b/Base/ctkTest.h
@@ -97,8 +97,8 @@ static void mouseEvent(QTest::MouseAction action, QWidget *widget, Qt::MouseButt
     {
     static const char *mouseActionNames[] =
         { "MousePress", "MouseRelease", "MouseClick", "MouseDClick", "MouseMove" };
-    QString warning = QString::fromLatin1("Mouse event \"%1\" not accepted by receiving widget");
-    QTest::qWarn(warning.arg(QString::fromLatin1(mouseActionNames[static_cast<int>(action)])).toLatin1());
+    QString warning = QLatin1String("Mouse event \"%1\" not accepted by receiving widget");
+    QTest::qWarn(warning.arg(QLatin1String(mouseActionNames[static_cast<int>(action)])).toLocal8Bit());
     }
 }
 

--- a/Main.cpp
+++ b/Main.cpp
@@ -186,15 +186,23 @@ int appLauncherMain(int argc, char** argv)
 
 // --------------------------------------------------------------------------
 #ifndef CTKAPPLAUNCHER_WITHOUT_CONSOLE_IO_SUPPORT
+// NOTE: On Windows, wmain should be used to allow non-ASCII characters in command-line arguments
 int main(int argc, char *argv[])
 {
+  // Uncomment the next two lines to stop at application start (to give a chance to connect with a debugger)
+  // std::cout << "Attach debugger and hit Enter" << std::endl;
+  // std::cin.get();
+
   return appLauncherMain(argc, argv);
 }
 #elif defined Q_OS_WIN32
-int __stdcall WinMain(HINSTANCE hInstance,
+int __stdcall wWinMain(HINSTANCE hInstance,
                       HINSTANCE hPrevInstance,
-                      LPSTR lpCmdLine, int nShowCmd)
+                      PWSTR lpCmdLine, int nShowCmd)
 {
+  // Uncomment the next line to stop at application start (to give a chance to connect with a debugger)
+  // int msgboxID = MessageBox(NULL, "Attach your debugger", "Debug", MB_ICONWARNING);
+
   Q_UNUSED(hInstance);
   Q_UNUSED(hPrevInstance);
   Q_UNUSED(nShowCmd);


### PR DESCRIPTION
Should fix the issues described here: https://discourse.slicer.org/t/slicer-ignoring-command-line-path-with-accents/24569
