### PR TITLE
Use more inclusive language

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - run:
          name: Upload release and prerelease packages
          command: |
-           if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
+           if [[ "${CIRCLE_BRANCH}" == "main" ]]; then
              pip install -U scikit-ci-addons
              cd /usr/src/AppLauncher
              ci_addons publish_github_release commontk/applauncher \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-    - master
+    - main
     tags:
     - 'v*'
 

--- a/Docs/Doxyfile.txt.in
+++ b/Docs/Doxyfile.txt.in
@@ -1315,7 +1315,7 @@ CHM_FILE               =
 HHC_LOCATION           =
 
 # The GENERATE_CHI flag controls if a separate .chi index file is generated
-# (YES) or that it should be included in the master .chm file (NO).
+# (YES) or that it should be included in the main .chm file (NO).
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Build Status
 | [![][circleci]][circleci-lnk]  | [![][gha]][gha-lnk]           | [![][appveyor]][appveyor-lnk] |
 
 
-[appveyor]: https://ci.appveyor.com/api/projects/status/s6jen6mde8n72o8u/branch/master?svg=true
+[appveyor]: https://ci.appveyor.com/api/projects/status/s6jen6mde8n72o8u/branch/main?svg=true
 [appveyor-lnk]: https://ci.appveyor.com/project/commontk/AppLauncher
 
 [circleci]: https://circleci.com/gh/commontk/AppLauncher.svg?style=svg
 [circleci-lnk]: https://circleci.com/gh/commontk/AppLauncher
 
-[gha]: https://github.com/commontk/AppLauncher/actions/workflows/CI.yml/badge.svg?branch=master
+[gha]: https://github.com/commontk/AppLauncher/actions/workflows/CI.yml/badge.svg?branch=main
 [gha-lnk]: https://github.com/commontk/AppLauncher/actions/workflows/CI.yml
 
 contributing
@@ -35,7 +35,7 @@ little bit helps, and credit will always be given.
 
 See [CONTRIBUTING.md][contributing] for more details.
 
-[contributing]: https://github.com/commontk/AppLauncher/blob/master/CONTRIBUTING.md
+[contributing]: https://github.com/commontk/AppLauncher/blob/main/CONTRIBUTING.md
 
 maintainers: how to make a release ?
 ------------------------------------
@@ -76,14 +76,14 @@ maintainers: how to make a release ?
 4. Tag the release. Requires a GPG key with signatures:
 
     ```bash
-    git tag -s -m "CTKAppLauncher $tag" $tag master
+    git tag -s -m "CTKAppLauncher $tag" $tag main
     ```
 
-5. Publish the tag and `master` branch to trigger the release build
+5. Publish the tag and `main` branch to trigger the release build
 
     ```bash
     git push origin $tag && \
-    git push origin master
+    git push origin main
     ```
 
 _**Important:** Until issue [scikit-build/scikit-ci-addons/issues/96](https://github.com/scikit-build/scikit-ci-addons/issues/96) is addressed, macOS release package should be manually downloaded from the GitHub Actions artifact and uploaded as a GitHub release asset._
@@ -100,7 +100,7 @@ _**Important:** Until issue [scikit-build/scikit-ci-addons/issues/96](https://gi
 7. Publish the changes:
 
     ```bash
-    git push origin master
+    git push origin main
     ```
 
 License

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 
 branches:
  only:
- - master
+ - main
 skip_tags: true
 
 shallow_clone: false


### PR DESCRIPTION
_Adapted from https://github.com/Slicer/Slicer/pull/6277_

This PR follows recommendations from https://tools.ietf.org/id/draft-knodel-terminology-09.html which have been adopted by many others in the community for work towards the greater good. Although it is often nice to maintain using current terminology, as it relates to improving inclusivity, this should be higher priority.

GitHub has improved the ability to rename a branch (https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch) which makes it easy to switch to a new name with minimal consequences.

Before merging the following should be done:

* [x] Rename default branch for https://github.com/commontk/AppLauncher/tree/master