### PR TITLE
COMP: Fix GitHub workflow using current "macos-12" runner

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,8 +10,8 @@ on:
 
 jobs:
   tests:
-    runs-on: macos-10.15
-    name: macos-10.15
+    runs-on: macos-12
+    name: macos-12
     steps:
     - uses: actions/checkout@v2
       with:
@@ -30,9 +30,6 @@ jobs:
 
     - name: Install scikit-ci-addons
       run: pip install -U scikit-ci-addons
-
-    - name: Specific XCode version
-      run: sudo xcode-select -s "/Applications/Xcode_11.7.app"
 
     - name: Download Qt archive
       uses: carlosperate/download-file-action@v1.1.1


### PR DESCRIPTION
Runner "macos-10.15" was removed on 2022.08.30
See https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

> The macos-11 label has been deprecated and will no longer be available
> after 28 June 2024.

Source: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-private-repositories