### PR TITLE
COMP: Fix appveyor package upload using "Python38-x64" instead of "Python27-x64"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ environment:
       APPLAUNCHER_BUILD_WRAPPER: ""
       BLOCK: "0"
 
-  PYTHON_DIR: "C:\\Python27-x64"
+  PYTHON_DIR: "C:\\Python38-x64"
   PATH: "%PYTHON_DIR%;%PYTHON_DIR%\\Scripts;%PATH%"
   GITHUB_TOKEN:
     secure: tBrUc3IczNjD3kBiOYQ0bYF9tDXv7jQU33G3vZhhhbSDtxWVNeZo7iKmEuXyDbkw


### PR DESCRIPTION
This commit attempts to address the following errors:

```
pip : DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More
details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
At line:1 char:1
+ pip install scikit-ci-addons==0.18.0
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (DEPRECATION: Py...ython-2-support:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError

[...]

ERROR: Could not find a version that satisfies the requirement backoff~=2.1.2 (from githubrelease>=1.5.6->scikit-ci-addons==0.18.0) (from versions: 1.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, 1.0.7, 1.1.0, 1.2.0, 1.2.1,
1.3.0, 1.3.1, 1.3.2, 1.4.0, 1.4.1, 1.4.2, 1.4.3, 1.5.0, 1.6.0, 1.7.0, 1.7.1, 1.8.0, 1.8.1, 1.9.0, 1.9.1, 1.9.2, 1.10.0, 1.11.0, 1.11.1)
ERROR: No matching distribution found for backoff~=2.1.2 (from githubrelease>=1.5.6->scikit-ci-addons==0.18.0)
```