### PR TITLE
COMP: Update Appveyor ensuring latest version of scikit-ci-addons is installed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,7 @@ test_script:
         $host.SetShouldExit($LastExitCode)
   # Upload release and prerelease packages
   - ps: |
-      pip install scikit-ci-addons==0.18.0
+      pip install -U scikit-ci-addons
       ci_addons publish_github_release commontk/applauncher       `
         --exit-success-if-missing-token                           `
         --prerelease-sha main                                     `


### PR DESCRIPTION
Attempt to fix the following error:

```
ci_addons : Traceback (most recent call last):
At line:2 char:1
+ ci_addons publish_github_release commontk/applauncher       `
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (Traceback (most recent call last)::String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
  File "c:\python38-x64\lib\site-packages\anyci\publish_github_release.py", line 443, in <module>
    main()
  File "c:\python38-x64\lib\site-packages\anyci\publish_github_release.py", line 436, in main
    _upload_prerelease(args)
  File "c:\python38-x64\lib\site-packages\anyci\publish_github_release.py", line 309, in _upload_prerelease
    gh_release_create(
  File "c:\python38-x64\lib\site-packages\github_release.py", line 132, in with_check_for_credentials
    return func(*args, **kwargs)
  File "c:\python38-x64\lib\site-packages\github_release.py", line 526, in gh_release_create
    if get_release(repo_name, tag_name) is not None:
  File "c:\python38-x64\lib\site-packages\backoff\_sync.py", line 48, in retry
    ret = target(*args, **kwargs)
  File "c:\python38-x64\lib\site-packages\github_release.py", line 337, in get_release
    releases = get_releases(repo_name)
  File "c:\python38-x64\lib\site-packages\backoff\_sync.py", line 105, in retry
    ret = target(*args, **kwargs)
  File "c:\python38-x64\lib\site-packages\github_release.py", line 316, in get_releases
    _recursive_gh_get(
  File "c:\python38-x64\lib\site-packages\github_release.py", line 171, in _recursive_gh_get
    response.raise_for_status()
  File "c:\python38-x64\lib\site-packages\requests\models.py", line 1024, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://api.github.com/repos/commontk/applauncher/releases
Command executed with exception:   File "c:\python38-x64\lib\site-packages\anyci\publish_github_release.py", line 443, in <module>
    main()
  File "c:\python38-x64\lib\site-packages\anyci\publish_github_release.py", line 436, in main
    _upload_prerelease(args)
  File "c:\python38-x64\lib\site-packages\anyci\publish_github_release.py", line 309, in _upload_prerelease
    gh_release_create(
  File "c:\python38-x64\lib\site-packages\github_release.py", line 132, in with_check_for_credentials
    return func(*args, **kwargs)
  File "c:\python38-x64\lib\site-packages\github_release.py", line 526, in gh_release_create
    if get_release(repo_name, tag_name) is not None:
  File "c:\python38-x64\lib\site-packages\backoff\_sync.py", line 48, in retry
    ret = target(*args, **kwargs)
  File "c:\python38-x64\lib\site-packages\github_release.py", line 337, in get_release
    releases = get_releases(repo_name)
  File "c:\python38-x64\lib\site-packages\backoff\_sync.py", line 105, in retry
    ret = target(*args, **kwargs)
  File "c:\python38-x64\lib\site-packages\github_release.py", line 316, in get_releases
    _recursive_gh_get(
  File "c:\python38-x64\lib\site-packages\github_release.py", line 171, in _recursive_gh_get
    response.raise_for_status()
  File "c:\python38-x64\lib\site-packages\requests\models.py", line 1024, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://api.github.com/repos/commontk/applauncher/releases
pip install scikit-ci-addons
Requirement already satisfied: scikit-ci-addons in c:\python38-x64\lib\site-packages (0.18.0)
```

Source: https://ci.appveyor.com/project/commontk/applauncher/builds/50136457/job/ws8wh55iq69g6vkh