### PR TITLE
COMP: Attempt to fix restoration of cache in upload job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,23 @@
 version: 2
 jobs:
   build-package-test:
-    working_directory: /usr/src/AppLauncher
+    working_directory: /home/circleci/project/AppLauncher
     docker:
       - image: commontk/qt-static:4.8.6-centos-5.5
     steps:
       - checkout
       - run:
          command: |
-           /usr/src/AppLauncher/docker-build-package.sh
+           /home/circleci/project/AppLauncher/docker-build-package.sh
       - save_cache:
           key: applauncher-src-{{ .Revision }}
-          paths: /usr/src/AppLauncher
+          paths: /home/circleci/project/AppLauncher
       - save_cache:
           key: applauncher-build-{{ .Revision }}
-          paths: /usr/src/AppLauncher-build
+          paths: /home/circleci/project/AppLauncher-build
 
   test:
+    working_directory: /home/circleci/project/AppLauncher
     docker:
       - image: thewtex/opengl:debian
     steps:
@@ -36,12 +37,13 @@ jobs:
 
       - run:
          command: |
-           export APP="sudo chown -R user.user /usr/src/AppLauncher-build && cd /usr/src/AppLauncher-build && ctest -LE 'CompilerRequired' -VV"
+           export APP="sudo chown -R user.user /home/circleci/project/AppLauncher-build && cd /home/circleci/project/AppLauncher-build && ctest -LE 'CompilerRequired' -VV"
            /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
            [ "$(cat /tmp/graphical-app.return_code)" = 0 ]
 
 
   upload:
+    working_directory: /home/circleci/project/AppLauncher
     docker:
       - image: cimg/python:3.10
     steps:
@@ -59,14 +61,14 @@ jobs:
            # See https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html#ssl-module-is-compiled-with-openssl-1-0-2-k-fips
            python -c "import requests"
            if [[ "${CIRCLE_BRANCH}" == "main" ]]; then
-             cd /usr/src/AppLauncher
+             cd /home/circleci/project/AppLauncher
              ci_addons publish_github_release commontk/applauncher \
                --exit-success-if-missing-token                     \
                --prerelease-sha main \
-               --prerelease-packages /usr/src/AppLauncher-build/CTKAppLauncher-*.tar.gz \
+               --prerelease-packages /home/circleci/project/AppLauncher-build/CTKAppLauncher-*.tar.gz \
                --prerelease-packages-clear-pattern "*linux*"                     \
                --prerelease-packages-keep-pattern "*<COMMIT_SHORT_SHA>*" \
-               --release-packages /usr/src/AppLauncher-build/CTKAppLauncher-*.tar.gz
+               --release-packages /home/circleci/project/AppLauncher-build/CTKAppLauncher-*.tar.gz
            fi
 workflows:
   version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ FROM commontk/qt-static:4.8.6-centos-5.5
 MAINTAINER CommonTK Community <ctk-developers@commontk.org>
 # Build and package the CTK AppLauncher
 
-WORKDIR /usr/src
+WORKDIR /home/circleci/project
 
 RUN git clone https://github.com/commontk/AppLauncher.git
-VOLUME /usr/src/AppLauncher
+VOLUME /home/circleci/project/AppLauncher
 
-RUN mkdir /usr/src/AppLauncher-build
-WORKDIR /usr/src/AppLauncher-build
+RUN mkdir /home/circleci/project/AppLauncher-build
+WORKDIR /home/circleci/project/AppLauncher-build
 ADD docker-build-package.sh /usr/bin/build-package.sh
 RUN /usr/bin/build-package.sh
-VOLUME /usr/src/AppLauncher-build
+VOLUME /home/circleci/project/AppLauncher-build

--- a/docker-build-package.sh
+++ b/docker-build-package.sh
@@ -2,15 +2,15 @@
 
 set -ex
 
-mkdir -p /usr/src/AppLauncher-build
-cd /usr/src/AppLauncher-build
+mkdir -p /home/circleci/project/AppLauncher-build
+cd /home/circleci/project/AppLauncher-build
 rm -rf *
 
 cmake \
   -DCMAKE_BUILD_TYPE:STRING=Release \
   -DBUILD_TESTING:BOOL=ON \
   -DQT_QMAKE_EXECUTABLE:FILEPATH=/usr/src/qt-everywhere-opensource-release-build-4.8.6/bin/qmake \
-    /usr/src/AppLauncher
+    /home/circleci/project/AppLauncher
 make -j$(grep -c processor /proc/cpuinfo)
 make package
 ctest -L 'CompilerRequired' -j$(grep -c processor /proc/cpuinfo)


### PR DESCRIPTION
This commit is an attempt to fix errors like the following:

```
[...]

Found a cache from build 718 at applauncher-build-934889f29d7d1ea60adf7b6d8844028749872863
Size: 103 MiB
Cached paths:
  * /usr/src/AppLauncher-build

Downloading cache archive...
Validating cache...
Download duration for cache file /tmp/cache1192561374: 2.771237192s

Unarchiving cache...
Skipping writing "usr/src/AppLauncher-build/" - mkdir /usr/src/AppLauncher-build: permission denied
Skipping writing "usr/src/AppLauncher-build/Base/" - mkdir /usr/src/AppLauncher-build: permission denied

[...]

/bin/bash: line 6: cd: /usr/src/AppLauncher: No such file or directory
```