### PR TITLE
ci: Add Linux test job using dockbuild and Qt static archive 

### DIFF
--- a/.github/scripts/dockbuild_with_qt_env.sh
+++ b/.github/scripts/dockbuild_with_qt_env.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+err() { echo -e >&2 "ERROR: $*\n"; }
+die() { err "$@"; exit 1; }
+
+if [[ $# -lt 1 ]]; then
+  die "Usage: $0 <qt-archive-basename> [args...]"
+fi
+
+qt_archive_basename="$1"
+shift 1
+
+Qt5_DIR=/work/${qt_archive_basename}
+
+if [[ ! -d "$Qt5_DIR" ]]; then
+  die "Qt5_DIR env. variable is set to nonexistent directory: '${Qt5_DIR}'"
+fi
+
+# Rename "Qt5Gui_QVncIntegrationPlugin.cmake" to workaround the follwowing error:
+#
+# CMake Error at /work/qt-5.15.2-manylinux2.28-static-x86_64/lib/cmake/Qt5Gui/Qt5Gui_QVncIntegrationPlugin.cmake:8 (find_package):
+#   Could not find a package configuration file provided by "Qt5Network"
+#   (requested version 1.0.0) with any of the following names:
+#
+#     Qt5NetworkConfig.cmake
+#     qt5network-config.cmake
+#
+#   Add the installation prefix of "Qt5Network" to CMAKE_PREFIX_PATH or set
+#   "Qt5Network_DIR" to a directory containing one of the above files.  If
+#   "Qt5Network" provides a separate development package or SDK, be sure it has
+#   been installed.
+# Call Stack (most recent call first):
+#   /work/qt-5.15.2-manylinux2.28-static-x86_64/lib/cmake/Qt5Gui/Qt5GuiConfig.cmake:394 (include)
+#   /work/qt-5.15.2-manylinux2.28-static-x86_64/lib/cmake/Qt5Widgets/Qt5WidgetsConfig.cmake:219 (find_package)
+#   /work/qt-5.15.2-manylinux2.28-static-x86_64/lib/cmake/Qt5/Qt5Config.cmake:28 (find_package)
+#   CMakeLists.txt:267 (find_package)
+#
+if [[ -f ${Qt5_DIR}/lib/cmake/Qt5Gui/Qt5Gui_QVncIntegrationPlugin.cmake ]]; then
+  mv \
+    ${Qt5_DIR}/lib/cmake/Qt5Gui/Qt5Gui_QVncIntegrationPlugin.cmake \
+    ${Qt5_DIR}/lib/cmake/Qt5Gui/Qt5Gui_QVncIntegrationPlugin.cmake.disabled
+fi
+
+gosu root dnf install -y \
+  libxkbcommon-devel \
+  libxkbcommon-x11-devel \
+  xcb-util-devel \
+  xcb-util-image-devel \
+  xcb-util-keysyms-devel \
+  xcb-util-renderutil-devel \
+  xcb-util-wm-devel
+
+$@

--- a/.github/scripts/dockbuild_xvfb_wrapper.sh
+++ b/.github/scripts/dockbuild_xvfb_wrapper.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+gosu root dnf install -y \
+  xorg-x11-server-Xvfb \
+  xorg-x11-server-Xorg \
+  mesa-dri-drivers \
+  glx-utils
+
+function cleanup() {
+  echo "Cleaning up..."
+  local xvfb_pids=`ps aux | grep tmp/xvfb-run | grep -v grep | awk '{print $2}'`
+  if [ "$xvfb_pids" != "" ]; then
+      echo "Killing the following xvfb processes: $xvfb_pids"
+      sudo kill $xvfb_pids
+  else
+      echo "No xvfb processes to kill"
+  fi
+}
+trap cleanup EXIT
+
+xvfb-run --auto-servernum $@

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Test
         shell: pwsh
         run: |
-          $cmd = "${{ matrix.APPLAUNCHER_BUILD_WRAPPER }} ctest -C Release --test-dir build -j4 -VV"
+          $cmd = "${{ matrix.APPLAUNCHER_BUILD_WRAPPER }} ctest -C Release --test-dir build --output-on-failure -j4"
           Invoke-Expression $cmd
           $host.SetShouldExit($LastExitCode)
 
@@ -187,6 +187,7 @@ jobs:
                ctest \
                  --test-dir build \
                  --build-config Release \
+                 --output-on-failure \
                  --parallel $(nproc)
 
       - name: Publish packages
@@ -266,7 +267,7 @@ jobs:
       - name: Test
         run: |
           cd build
-          ctest -LE XDisplayRequired -VV
+          ctest -LE XDisplayRequired --output-on-failure
 
       - name: Publish packages
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -165,24 +165,25 @@ jobs:
 
       - name: Configure
         run: |
+          mkdir -p build
           ${dockbuild_script} \
-            cmake \
-              -G Ninja \
-              -DQt5_DIR:PATH=/work/${qt_archive_basename}/lib/cmake/Qt5 \
-              -DCMAKE_BUILD_TYPE:STRING=Release \
-              -DBUILD_TESTING:BOOL=ON \
-              -S src \
-              -B build
+            src/.github/scripts/dockbuild_with_qt_env.sh "${qt_archive_basename}" \
+              cmake \
+                -DQt5_DIR:PATH=/work/${qt_archive_basename}/lib/cmake/Qt5 \
+                -DCTKAppLauncher_BUILD_DIR:PATH=build \
+                -P src/linux-static-configure.cmake
 
       - name: Build
         run: |
           ${dockbuild_script} \
-            cmake --build build
+            src/.github/scripts/dockbuild_with_qt_env.sh "${qt_archive_basename}" \
+              cmake --build build
 
       - name: Test
         run: |
           ${dockbuild_script} \
-            ./src/.github/scripts/dockbuild_xvfb_wrapper.sh \
+            src/.github/scripts/dockbuild_with_qt_env.sh "${qt_archive_basename}" \
+            src/.github/scripts/dockbuild_xvfb_wrapper.sh \
                ctest \
                  --test-dir build \
                  --build-config Release \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -130,6 +130,92 @@ jobs:
     #  env:
     #    GITHUB_TOKEN: secrets.COMMONTKBOT_GITHUB_TOKEN
 
+  linux-tests:
+    runs-on: ubuntu-latest
+    env:
+      qt_archive_basename: qt-5.15.2-manylinux2.28-static-x86_64
+      qt_archive_sha256: e5e9a19a18a3e1e896691173dd23a668781d7154238d2e6fdd4996ca30b1f1e3
+      dockbuild_image: almalinux8-devtoolset14-gcc14
+      dockbuild_script: ./dockbuild-almalinux8-devtoolset14-gcc14-latest
+    name: ubuntu-latest [almalinux8-devtoolset14-gcc14]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: src
+
+      - name: Download Qt archive
+        uses: carlosperate/download-file-action@v2.0.2
+        with:
+          file-url:
+            "https://github.com/jcfr/qt-static-build/releases/download/${{
+            env.qt_archive_basename }}/${{ env.qt_archive_basename }}.tar.zst"
+          sha256: "${{ env.qt_archive_sha256 }}"
+
+      - name: Extract Qt archive
+        run: |
+          mkdir -p $qt_archive_basename
+          tar --zstd -xvf ${qt_archive_basename}.tar.zst -C ${qt_archive_basename}
+
+      - name: Pull build enviromment
+        run: |
+          docker pull dockbuild/${dockbuild_image}:latest
+          docker run --rm dockbuild/${dockbuild_image}:latest > ${dockbuild_script}
+          chmod u+x ${dockbuild_script}
+
+      - name: Configure
+        run: |
+          ${dockbuild_script} \
+            cmake \
+              -G Ninja \
+              -DQt5_DIR:PATH=/work/${qt_archive_basename}/lib/cmake/Qt5 \
+              -DCMAKE_BUILD_TYPE:STRING=Release \
+              -DBUILD_TESTING:BOOL=ON \
+              -S src \
+              -B build
+
+      - name: Build
+        run: |
+          ${dockbuild_script} \
+            cmake --build build
+
+      - name: Test
+        run: |
+          ${dockbuild_script} \
+            ./src/.github/scripts/dockbuild_xvfb_wrapper.sh \
+               ctest \
+                 --test-dir build \
+                 --build-config Release \
+                 --parallel $(nproc)
+
+      - name: Publish packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-packages
+          path: build/CTKAppLauncher-*.tar.gz
+
+    #- name: Setup Python
+    #  uses: actions/setup-python@v5
+    #  with:
+    #    python-version: '3.12'
+
+    #- name: Install scikit-ci-addons
+    #  run: pip install -U scikit-ci-addons
+
+    # See https://github.com/scikit-build/scikit-ci-addons/issues/96
+    #- name: Publish packages
+    #  run: |
+    #    cd src
+    #    ci_addons publish_github_release commontk/applauncher \
+    #      --exit-success-if-missing-token \
+    #      --prerelease-sha main \
+    #      --prerelease-packages ../build/CTKAppLauncher-*.tar.gz \
+    #      --prerelease-packages-clear-pattern "*linux*" \
+    #      --prerelease-packages-keep-pattern "*<COMMIT_SHORT_SHA>*" \
+    #      --release-packages build/CTKAppLauncher-*.tar.gz
+    #  env:
+    #    GITHUB_TOKEN: secrets.COMMONTKBOT_GITHUB_TOKEN
+
   macos-tests:
     runs-on: macos-13
     name: macos-13

--- a/Base/Testing/Cpp/CMakeLists.txt
+++ b/Base/Testing/Cpp/CMakeLists.txt
@@ -3,14 +3,18 @@ set(KIT ${PROJECT_NAME})
 if(CTKAppLauncher_QT_VERSION VERSION_GREATER "4" AND WIN32)
   set(CMAKE_TESTDRIVER_EXTRA_INCLUDES "${CMAKE_TESTDRIVER_EXTRA_INCLUDES}
   #include <QtPlugin>
+  #if (defined QT_STATIC)
   Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
+  #endif
   ")
 endif()
 
 if(CTKAppLauncher_QT_VERSION VERSION_GREATER "4" AND UNIX AND NOT APPLE)
   set(CMAKE_TESTDRIVER_EXTRA_INCLUDES "${CMAKE_TESTDRIVER_EXTRA_INCLUDES}
   #include <QtPlugin>
+  #if (defined QT_STATIC)
   Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
+  #endif
   ")
 endif()
 

--- a/Base/Testing/Cpp/CMakeLists.txt
+++ b/Base/Testing/Cpp/CMakeLists.txt
@@ -7,6 +7,13 @@ if(CTKAppLauncher_QT_VERSION VERSION_GREATER "4" AND WIN32)
   ")
 endif()
 
+if(CTKAppLauncher_QT_VERSION VERSION_GREATER "4" AND UNIX AND NOT APPLE)
+  set(CMAKE_TESTDRIVER_EXTRA_INCLUDES "${CMAKE_TESTDRIVER_EXTRA_INCLUDES}
+  #include <QtPlugin>
+  Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
+  ")
+endif()
+
 add_library(CTKAppLauncherTestingHelper STATIC
   ctkAppLauncherTestingHelper.cpp
   ctkAppLauncherTestingHelper.h

--- a/Main.cpp
+++ b/Main.cpp
@@ -155,10 +155,14 @@ int appLauncherMain(int argc, char** argv)
     }
   else
     {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) && defined Q_OS_WIN32 && defined QT_STATIC)
     // Initialize platform plugin in static build
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) && defined Q_OS_WIN32 && defined QT_STATIC)
     Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
 #endif
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) && defined Q_OS_LINUX && defined QT_STATIC)
+    Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
+#endif
+
     app.reset(new QApplication(
                 appArguments.argumentCount(ctkAppArguments::ARG_REGULAR_LIST),
                 appArguments.argumentValues(ctkAppArguments::ARG_REGULAR_LIST)));

--- a/Testing/LauncherLib/CMakeLists.txt
+++ b/Testing/LauncherLib/CMakeLists.txt
@@ -112,5 +112,5 @@ set_property(TEST ${testname} APPEND PROPERTY DEPENDS ${build_step_testname})
 
 set_property(TEST ${testname} PROPERTY LABELS "ctkAppLauncher") # Remove "CompilerRequired" label
 if(TEST_TREE_TYPE STREQUAL "InstallTree")
-  set_tests_properties(${testname} PROPERTIES DEPENDS "InstallTree_AppLauncher-Install")
+  set_property(TEST ${testname} APPEND PROPERTY DEPENDS "InstallTree_AppLauncher-Install")
 endif()

--- a/Testing/LauncherLib/CMakeLists.txt
+++ b/Testing/LauncherLib/CMakeLists.txt
@@ -106,9 +106,10 @@ set(build_step_testname ${testname})
 
 applauncher_add_test(AppWithLauncherLib-RunStep ${test_args})
 set_property(TEST ${testname} APPEND PROPERTY DEPENDS ${build_step_testname})
+set(run_step_testname ${testname})
 
 applauncher_add_test(AppWithLauncherLib-RunWithLauncherStep ${test_args})
-set_property(TEST ${testname} APPEND PROPERTY DEPENDS ${build_step_testname})
+set_property(TEST ${testname} APPEND PROPERTY DEPENDS ${run_step_testname})
 
 set_property(TEST ${testname} PROPERTY LABELS "ctkAppLauncher") # Remove "CompilerRequired" label
 if(TEST_TREE_TYPE STREQUAL "InstallTree")

--- a/linux-static-configure.cmake
+++ b/linux-static-configure.cmake
@@ -1,0 +1,76 @@
+#
+# Configure the AppLauncher project using a statically built Qt and a Linux-based environment.
+#
+# This script sets up the Linux build environment, generates an initial CMake cache,
+# and runs `cmake` to configure the project in a given build directory.
+#
+# Usage:
+#
+#   cmake \
+#     -DQt5_DIR:PATH=/path/to/qt/lib/cmake/Qt5 \
+#     -DCTKAppLauncher_BUILD_DIR:PATH=/path/to/build \
+#     -DCTKAppLauncher_SOURCE_DIR:PATH=/path/to/src \
+#     -P /path/to/linux-static-configure.cmake
+#
+# Required variables:
+# - Qt5_DIR: Path to the static Qt installation's CMake config
+# - CTKAppLauncher_BUILD_DIR: Destination directory for the CMake build
+#
+# Optional:
+# - CTKAppLauncher_SOURCE_DIR: If not set, defaults to ${CMAKE_CURRENT_SOURCE_DIR}
+#
+# Prebuilt static Qt archives can be found at:
+#   https://github.com/jcfr/qt-static-build
+#
+
+if(NOT EXISTS "${Qt5_DIR}")
+  message(FATAL_ERROR "Qt5_DIR is set to a non-existent directory [${Qt5_DIR}]")
+endif()
+
+if(NOT DEFINED CTKAppLauncher_SOURCE_DIR)
+  set(CTKAppLauncher_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+endif()
+if(NOT EXISTS "${CTKAppLauncher_SOURCE_DIR}")
+  message(FATAL_ERROR "CTKAppLauncher_SOURCE_DIR is set to a non-existent directory [${CTKAppLauncher_SOURCE_DIR}]")
+endif()
+message(STATUS "Setting CTKAppLauncher_SOURCE_DIR: ${CTKAppLauncher_SOURCE_DIR}")
+
+if(NOT DEFINED CTKAppLauncher_BUILD_DIR)
+  message(FATAL_ERROR "CTKAppLauncher_BUILD_DIR is not set")
+endif()
+if(NOT EXISTS "${CTKAppLauncher_BUILD_DIR}")
+  message(FATAL_ERROR "CTKAppLauncher_BUILD_DIR is set to a non-existent directory [${CTKAppLauncher_BUILD_DIR}]")
+endif()
+message(STATUS "Setting CTKAppLauncher_BUILD_DIR: ${CTKAppLauncher_BUILD_DIR}")
+
+# Set QT_PREFIX_DIR assuming standard static Qt layout
+set(QT_PREFIX_DIR "${Qt5_DIR}/../../../")
+get_filename_component(QT_PREFIX_DIR ${QT_PREFIX_DIR} ABSOLUTE)
+message(STATUS "Setting QT_PREFIX_DIR: ${QT_PREFIX_DIR}")
+
+
+# Dependencies of QPA plugin needed for running GUI based application
+# and avoid runtime error: qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
+set(qt_qpa_plugin_static_libraries
+  ${QT_PREFIX_DIR}/plugins/platforms/libqxcb.a
+)
+set(qt_static_libraries
+  ${qt_qpa_plugin_static_libraries}
+)
+
+set(INITIAL_CACHE "
+CMAKE_BUILD_TYPE:STRING=Release
+BUILD_TESTING:BOOL=1
+CTKAppLauncher_QT_STATIC_LIBRARIES:STRING=${qt_static_libraries}
+Qt5_DIR:PATH=${Qt5_DIR}"
+)
+
+file(WRITE ${CTKAppLauncher_BUILD_DIR}/CMakeCache.txt "${INITIAL_CACHE}")
+
+execute_process(COMMAND
+  ${CMAKE_COMMAND}
+    -G Ninja
+    -S ${CTKAppLauncher_SOURCE_DIR}
+    -B ${CTKAppLauncher_BUILD_DIR}
+)
+

--- a/msvc-static-configure.cmake
+++ b/msvc-static-configure.cmake
@@ -34,7 +34,7 @@ if(NOT EXISTS "${Qt5_DIR}")
 endif()
 
 if(NOT DEFINED CTKAppLauncher_SOURCE_DIR)
-  set(CTKAppLauncher_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+  set(CTKAppLauncher_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 endif()
 if(NOT EXISTS "${CTKAppLauncher_SOURCE_DIR}")
   message(FATAL_ERROR "CTKAppLauncher_SOURCE_DIR is set to a non-existent directory [${CTKAppLauncher_SOURCE_DIR}]")
@@ -145,6 +145,7 @@ if(APPLAUNCHER_USE_NINJA)
   set(ENV{PATH} "${CMAKE_CURRENT_BINARY_DIR}/${archive_basename};$ENV{PATH}")
 endif()
 
+# Set QT_PREFIX_DIR assuming standard static Qt layout
 set(QT_PREFIX_DIR "${Qt5_DIR}/../../../")
 get_filename_component(QT_PREFIX_DIR ${QT_PREFIX_DIR} ABSOLUTE)
 message(STATUS "Setting QT_PREFIX_DIR: ${QT_PREFIX_DIR}")


### PR DESCRIPTION
This adds a `linux-tests` job to the GitHub Actions workflow that builds and tests the project in a self-contained container environment provided by `dockbuild`.

Highlights:
- Uses a statically built Qt 5.15.2 archive downloaded and extracted at runtime.
- Runs the build inside a container (`almalinux8-devtoolset14-gcc14`) launched via a wrapper script.
- Adds `.github/scripts/dockbuild_xvfb_wrapper.sh` to enable running GUI tests via `xvfb-run`, including cleanup logic.
