### PR TITLE
tests: Ensure launcher isolation per test to prevent parallel execution conflicts

### DIFF
--- a/Testing/Launcher/AppLauncher-Param-TestLauncherVersion.cmake
+++ b/Testing/Launcher/AppLauncher-Param-TestLauncherVersion.cmake
@@ -30,7 +30,7 @@ if(rv)
                       "directory [${launcher_binary_dir}]\n${ev}")
 endif()
 
-set(expected_msg "CTKAppLauncher launcher version ${launcher_version}
+set(expected_msg "${launcher_name} launcher version ${launcher_version}
 ")
 
 if(NOT ${expected_msg} STREQUAL ${ov})

--- a/Testing/Launcher/AppLauncher-TestSaveLauncherEnvironment.cmake
+++ b/Testing/Launcher/AppLauncher-TestSaveLauncherEnvironment.cmake
@@ -23,10 +23,6 @@ else()
   set(pathsep ":")
 endif()
 
-
-# Extract test name
-get_filename_component(testname ${CMAKE_CURRENT_LIST_FILE} NAME_WE)
-
 # --------------------------------------------------------------------------
 function(run_laucher expected_level)
   message(STATUS "Executing launcher for level [${expected_level}]")
@@ -35,7 +31,7 @@ function(run_laucher expected_level)
     -DTEST_SOURCE_DIR:PATH=${TEST_SOURCE_DIR}
     -DTEST_BINARY_DIR:PATH=${TEST_BINARY_DIR}
     -DEXPECTED_LEVEL:BOOL=${expected_level}
-    -DTEST_NAME:STRING=${testname}
+    -DTEST_NAME:STRING=${TEST_NAME}
     -DAppLauncherTestPrerequisites_COPY_LAUNCHER:BOOL=FALSE
     -P ${CMAKE_CURRENT_LIST_FILE}
     )

--- a/Testing/Launcher/AppLauncher-TestSaveLauncherEnvironment.cmake
+++ b/Testing/Launcher/AppLauncher-TestSaveLauncherEnvironment.cmake
@@ -23,6 +23,10 @@ else()
   set(pathsep ":")
 endif()
 
+
+# Extract test name
+get_filename_component(testname ${CMAKE_CURRENT_LIST_FILE} NAME_WE)
+
 # --------------------------------------------------------------------------
 function(run_laucher expected_level)
   message(STATUS "Executing launcher for level [${expected_level}]")
@@ -31,6 +35,7 @@ function(run_laucher expected_level)
     -DTEST_SOURCE_DIR:PATH=${TEST_SOURCE_DIR}
     -DTEST_BINARY_DIR:PATH=${TEST_BINARY_DIR}
     -DEXPECTED_LEVEL:BOOL=${expected_level}
+    -DTEST_NAME:STRING=${testname}
     -P ${CMAKE_CURRENT_LIST_FILE}
     )
   print_command_as_string("${command}")

--- a/Testing/Launcher/AppLauncher-TestSaveLauncherEnvironment.cmake
+++ b/Testing/Launcher/AppLauncher-TestSaveLauncherEnvironment.cmake
@@ -36,6 +36,7 @@ function(run_laucher expected_level)
     -DTEST_BINARY_DIR:PATH=${TEST_BINARY_DIR}
     -DEXPECTED_LEVEL:BOOL=${expected_level}
     -DTEST_NAME:STRING=${testname}
+    -DAppLauncherTestPrerequisites_COPY_LAUNCHER:BOOL=FALSE
     -P ${CMAKE_CURRENT_LIST_FILE}
     )
   print_command_as_string("${command}")

--- a/Testing/Launcher/AppLauncherTestPrerequisites.cmake.in
+++ b/Testing/Launcher/AppLauncherTestPrerequisites.cmake.in
@@ -100,7 +100,11 @@ if(AppLauncherTestPrerequisites_COPY_LAUNCHER)
     configure_file("${original_launcher_exe}" "${launcher_exe}" COPYONLY)
   endif()
 endif()
-message(STATUS "Using unique launcher: ${launcher_exe}")
+message(STATUS "Launcher isolation details:")
+message(STATUS "  TEST_NAME            = ${TEST_NAME}")
+message(STATUS "  Hashed suffix        = ${launcher_suffix}")
+message(STATUS "  Original launcher    = ${original_launcher_exe}")
+message(STATUS "  Isolated launcher    = ${launcher_exe}")
 
 # --------------------------------------------------------------------------
 # Remove settings file if any

--- a/Testing/Launcher/AppLauncherTestPrerequisites.cmake.in
+++ b/Testing/Launcher/AppLauncherTestPrerequisites.cmake.in
@@ -75,7 +75,6 @@ endif()
 # --------------------------------------------------------------------------
 # Isolate launcher instances to prevent file access conflicts across parallel tests.
 # Each test gets a uniquely named copy of the launcher executable.
-
 set(original_launcher_name ${launcher_name})
 set(original_launcher ${launcher})
 set(original_launcher_exe ${launcher_exe})
@@ -91,10 +90,15 @@ set(launcher ${launcher_dir}/${launcher_name})
 set(launcher_exe ${launcher}${CMAKE_EXECUTABLE_SUFFIX})
 
 # copy launcher
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.21")
-  file(COPY_FILE ${original_launcher_exe} ${launcher_exe})
-else()
-  configure_file("${original_launcher_exe}" "${launcher_exe}" COPYONLY)
+if(NOT DEFINED AppLauncherTestPrerequisites_COPY_LAUNCHER)
+  set(AppLauncherTestPrerequisites_COPY_LAUNCHER 1)
+endif()
+if(AppLauncherTestPrerequisites_COPY_LAUNCHER)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.21")
+    file(COPY_FILE ${original_launcher_exe} ${launcher_exe})
+  else()
+    configure_file("${original_launcher_exe}" "${launcher_exe}" COPYONLY)
+  endif()
 endif()
 message(STATUS "Using unique launcher: ${launcher_exe}")
 

--- a/Testing/Launcher/AppLauncherTestPrerequisites.cmake.in
+++ b/Testing/Launcher/AppLauncherTestPrerequisites.cmake.in
@@ -73,6 +73,32 @@ if (NOT EXISTS ${launcher_exe})
 endif()
 
 # --------------------------------------------------------------------------
+# Isolate launcher instances to prevent file access conflicts across parallel tests.
+# Each test gets a uniquely named copy of the launcher executable.
+
+set(original_launcher_name ${launcher_name})
+set(original_launcher ${launcher})
+set(original_launcher_exe ${launcher_exe})
+
+if(NOT DEFINED TEST_NAME)
+  message(FATAL_ERROR "TEST_NAME variable is not defined.")
+endif()
+string(MD5 testname_hash "${TEST_NAME}")
+string(SUBSTRING "${testname_hash}" 0 8 launcher_suffix)
+
+set(launcher_name "${original_launcher_name}_${launcher_suffix}")
+set(launcher ${launcher_dir}/${launcher_name})
+set(launcher_exe ${launcher}${CMAKE_EXECUTABLE_SUFFIX})
+
+# copy launcher
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.21")
+  file(COPY_FILE ${original_launcher_exe} ${launcher_exe})
+else()
+  configure_file("${original_launcher_exe}" "${launcher_exe}" COPYONLY)
+endif()
+message(STATUS "Using unique launcher: ${launcher_exe}")
+
+# --------------------------------------------------------------------------
 # Remove settings file if any
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E remove -f ${launcher}LauncherSettings.ini)
@@ -81,7 +107,7 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E remove -f ${launcher}AdditionalLaunc
 
 # --------------------------------------------------------------------------
 set(expected_help_text "Usage
-  CTKAppLauncher [options]
+  ${launcher_name} [options]
 
 Options
   --launcher-help                                 Display help

--- a/Testing/Launcher/CMakeLists.txt
+++ b/Testing/Launcher/CMakeLists.txt
@@ -63,6 +63,7 @@ function(applauncher_add_test name)
     -DTEST_SOURCE_DIR:PATH=${CMAKE_CURRENT_SOURCE_DIR}
     -DTEST_BINARY_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}
     -DTEST_CONFIGURATION:STRING=$<CONFIG>
+    -DTEST_NAME:STRING=${name}
     ${options}
     -P ${CMAKE_CURRENT_SOURCE_DIR}/${testscript}.cmake)
   # Current test depends on all previous tests

--- a/Testing/LauncherLib/CMakeLists.txt
+++ b/Testing/LauncherLib/CMakeLists.txt
@@ -20,6 +20,7 @@ function(applauncher_add_test testname)
     -DTEST_SOURCE_DIR:PATH=${CMAKE_CURRENT_SOURCE_DIR}
     -DTEST_BINARY_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}
     -DTEST_CONFIGURATION:STRING=$<CONFIG>
+    -DTEST_NAME:STRING=${testname}
     ${ARGN}
     -P ${CMAKE_CURRENT_SOURCE_DIR}/${testscript}.cmake)
   # Current test depends on all previous tests


### PR DESCRIPTION
This update addresses a race condition that occurred during parallel test execution (`ctest -jN`), where multiple tests using the same launcher binary would write or read from conflicting files (e.g., `LauncherSettings.ini`), leading to nondeterministic failures.

Test environments are now fully isolated per launcher instance. It prevents `.ini` or log file conflicts and improves reliability in parallel test runs.

### Summary

* Each test now receives a unique copy of the launcher executable.
* The test name is hashed (`MD5(TEST_NAME)`), and the suffix is appended to the launcher name.
* All references to the launcher within the test environment (`launcher_name`, `launcher`, `launcher_exe`) are updated accordingly.
* Launcher copying is done using `file(COPY_FILE)` (or `configure_file(COPYONLY)` for CMake < 3.21).
* A status message is printed during configuration to aid in diagnostics.
