### PR TITLE
Improve CI security and add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,13 +31,13 @@ jobs:
 
     name: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           path: src
 
       - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v1.12
+        uses: jwlawson/actions-setup-cmake@884cf5c591490f86b788d68b6f585f26235578d6 # v1.12
         with:
           cmake-version: 3.22.2
 
@@ -47,7 +47,7 @@ jobs:
           mkdir build
 
       - name: Download Qt archive
-        uses: carlosperate/download-file-action@v2.0.2
+        uses: carlosperate/download-file-action@3ec6fcef61e19eaaa0236a95fbaf333f2baf341e # v2.0.2
         with:
           file-url: "https://github.com/jcfr/qt-static-build/releases/download/applauncher-5.11.2-vs2017/qt-5.11.2-static-ltcg-msvc2017-x86.zip"
           sha256: "e2531150a00d68624257d7b40c5b9d7c07feab55fbf98f7cda31f08b74b71c01"
@@ -108,7 +108,7 @@ jobs:
 
       - name: Publish packages
         if: matrix.APPLAUNCHER_CMAKE_GENERATOR == 'Visual Studio 17 2022'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: win-packages
           path: build/CTKAppLauncher-*.tar.gz
@@ -145,13 +145,13 @@ jobs:
       dockbuild_script: ./dockbuild-almalinux8-devtoolset14-gcc14-latest
     name: ubuntu-latest [almalinux8-devtoolset14-gcc14]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           path: src
 
       - name: Download Qt archive
-        uses: carlosperate/download-file-action@v2.0.2
+        uses: carlosperate/download-file-action@3ec6fcef61e19eaaa0236a95fbaf333f2baf341e # v2.0.2
         with:
           file-url:
             "https://github.com/jcfr/qt-static-build/releases/download/${{
@@ -197,7 +197,7 @@ jobs:
                  --parallel $(nproc)
 
       - name: Publish packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: linux-packages
           path: build/CTKAppLauncher-*.tar.gz
@@ -228,18 +228,18 @@ jobs:
     runs-on: macos-13
     name: macos-13
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           path: src
 
       - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v1.12
+        uses: jwlawson/actions-setup-cmake@884cf5c591490f86b788d68b6f585f26235578d6 # v1.12
         with:
           cmake-version: 3.22.2
 
       - name: Download Qt archive
-        uses: carlosperate/download-file-action@v2.0.2
+        uses: carlosperate/download-file-action@3ec6fcef61e19eaaa0236a95fbaf333f2baf341e # v2.0.2
         with:
           file-url: "https://github.com/jcfr/qt-static-build/releases/download/qt-5.15.2-macosx10.13-static-x86_64/qt-5.15.2-macosx10.13-static-x86_64.tar.bz2"
           sha256: "13a1df0c939c22618fb979072c3c16191cb42f7759ea3d8ec344aa229a04bca0"
@@ -276,7 +276,7 @@ jobs:
           ctest -LE XDisplayRequired --output-on-failure
 
       - name: Publish packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: macos-packages
           path: build/CTKAppLauncher-*.tar.gz


### PR DESCRIPTION
This pull request improves the CI pipeline introducing these changes:

* Follow GitHub's security hardening recommendations pinning GitHub Actions to Full-Length Commit SHAs

* Add Dependabot Configuration to automate the update of GitHub Actions version.
