### PR TITLE
ci: Add Continuous  Deployment (CD) workflow

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,59 @@
+name: CD
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to publish artifacts for"
+        required: true
+  release:
+    types:
+      - published
+
+jobs:
+  upload-release-assets:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set TAG_NAME
+        id: vars
+        run: |
+          echo "TAG_NAME=${{ github.event.release.tag_name || inputs.tag }}" >> $GITHUB_OUTPUT
+
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0 # Required to resolve tag commits
+
+      - name: Resolve commit SHA for tag
+        id: resolve_sha
+        run: |
+          git fetch --tags
+          COMMIT_SHA=$(git rev-list -n 1 $TAG_NAME)
+          echo "COMMIT_SHA [$COMMIT_SHA]"
+          echo "commit-sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+        env:
+          TAG_NAME: ${{ steps.vars.outputs.TAG_NAME }}
+
+      - name: Download artifact
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v11
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: CI.yml
+          workflow_conclusion: success
+          commit: ${{ steps.resolve_sha.outputs.commit-sha }}
+          repo: ${{ github.repository }}
+          name: ".+-packages"
+          name_is_regexp: true
+
+      - name: List downloaded files
+        run: ls -1 -R
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            **/CTKAppLauncher-*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.COMMONTKBOT_GITHUB_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -199,11 +199,11 @@ jobs:
                 -DCTKAppLauncher_BUILD_DIR:PATH=build \
                 -P src/linux-static-configure.cmake
 
-      - name: Build
+      - name: Build and Package
         run: |
           ${dockbuild_script} \
             src/.github/scripts/dockbuild_with_qt_env.sh "${qt_archive_basename}" \
-              cmake --build build
+              cmake --build build --target package
 
       - name: Test
         run: |
@@ -283,13 +283,9 @@ jobs:
           CC: clang
           CXX: clang++
 
-      - name: Build
+      - name: Build and Package
         run: |
-          cmake --build build -- -j4
-
-      - name: Package
-        run: |
-          cmake --build build --target package
+          cmake --build build --target package -- -j4
 
       # Exclude tests requiring X Display
       - name: Test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -131,29 +131,6 @@ jobs:
           name: win-packages
           path: build/CTKAppLauncher-*.tar.gz
 
-    #- name: Setup Python
-    #  uses: actions/setup-python@v5
-    #  with:
-    #    python-version: '3.12'
-
-    #- name: Install scikit-ci-addons
-    #  run: pip install -U scikit-ci-addons
-
-    # See https://github.com/scikit-build/scikit-ci-addons/issues/96
-    #- name: Publish packages
-    #  shell: pwsh
-    #  run: |
-    #    cd build
-    #    ci_addons publish_github_release commontk/applauncher       `
-    #      --exit-success-if-missing-token                           `
-    #      --prerelease-sha main                                     `
-    #      --prerelease-packages CTKAppLauncher-*.tar.gz             `
-    #      --prerelease-packages-clear-pattern "*win*"               `
-    #      --prerelease-packages-keep-pattern "*<COMMIT_SHORT_SHA>*" `
-    #      --release-packages CTKAppLauncher-*.tar.gz
-    #  env:
-    #    GITHUB_TOKEN: secrets.COMMONTKBOT_GITHUB_TOKEN
-
   linux-tests:
     needs: changes
     if: ${{ needs.changes.outputs.paths-to-include == 'true' }}
@@ -222,28 +199,6 @@ jobs:
           name: linux-packages
           path: build/CTKAppLauncher-*.tar.gz
 
-    #- name: Setup Python
-    #  uses: actions/setup-python@v5
-    #  with:
-    #    python-version: '3.12'
-
-    #- name: Install scikit-ci-addons
-    #  run: pip install -U scikit-ci-addons
-
-    # See https://github.com/scikit-build/scikit-ci-addons/issues/96
-    #- name: Publish packages
-    #  run: |
-    #    cd src
-    #    ci_addons publish_github_release commontk/applauncher \
-    #      --exit-success-if-missing-token \
-    #      --prerelease-sha main \
-    #      --prerelease-packages ../build/CTKAppLauncher-*.tar.gz \
-    #      --prerelease-packages-clear-pattern "*linux*" \
-    #      --prerelease-packages-keep-pattern "*<COMMIT_SHORT_SHA>*" \
-    #      --release-packages build/CTKAppLauncher-*.tar.gz
-    #  env:
-    #    GITHUB_TOKEN: secrets.COMMONTKBOT_GITHUB_TOKEN
-
   macos-tests:
     needs: changes
     if: ${{ needs.changes.outputs.paths-to-include == 'true' }}
@@ -298,28 +253,6 @@ jobs:
         with:
           name: macos-packages
           path: build/CTKAppLauncher-*.tar.gz
-
-    #- name: Setup Python
-    #  uses: actions/setup-python@v5
-    #  with:
-    #    python-version: '3.12'
-
-    #- name: Install scikit-ci-addons
-    #  run: pip install -U scikit-ci-addons
-
-    # See https://github.com/scikit-build/scikit-ci-addons/issues/96
-    #- name: Publish packages
-    #  run: |
-    #    cd src
-    #    ci_addons publish_github_release commontk/applauncher \
-    #      --exit-success-if-missing-token \
-    #      --prerelease-sha main \
-    #      --prerelease-packages ../build/CTKAppLauncher-*.tar.gz \
-    #      --prerelease-packages-clear-pattern "*macosx*" \
-    #      --prerelease-packages-keep-pattern "*<COMMIT_SHORT_SHA>*" \
-    #      --release-packages build/CTKAppLauncher-*.tar.gz
-    #  env:
-    #    GITHUB_TOKEN: secrets.COMMONTKBOT_GITHUB_TOKEN
 
   pass: # This job does nothing and is only used for the branch protection
     if: always()


### PR DESCRIPTION
Introduces a new Continuous Deployment (CD) workflow that automates the publishing of release artifacts. This workflow can be triggered by a published release or manually by specifying a 
Git tag.
