### PR TITLE
style: Convert C++ source files from old-style "Whitesmiths" to "Allman" style

### DIFF
--- a/Base/Testing/Cpp/ctkAppArgumentsTest.cpp
+++ b/Base/Testing/Cpp/ctkAppArgumentsTest.cpp
@@ -179,16 +179,16 @@ void ctkAppArgumentsTester::testArgumentValues()
 
   ctkAppArguments appArguments(inputArgv.count(), inputArgv.values());
   foreach(const Self::ArgToFilterType& argToFilter, argToFilterList)
-    {
+  {
     appArguments.addArgumentToFilter(argToFilter);
-    }
+  }
 
   char** filtedArgumentsAsCharStarArray = appArguments.argumentValues(QFlags<ctkAppArguments::ArgListType>(filteringOption));
   QStringList filtedArguments;
   for(int index = 0; index < appArguments.argumentCount(QFlags<ctkAppArguments::ArgListType>(filteringOption)); ++index)
-    {
+  {
     filtedArguments << filtedArgumentsAsCharStarArray[index];
-    }
+  }
   QCOMPARE(filtedArguments, expectedArguments);
 }
 
@@ -210,9 +210,9 @@ void ctkAppArgumentsTester::testArgumentCount()
 
   ctkAppArguments appArguments(inputArgv.count(), inputArgv.values());
   foreach(const Self::ArgToFilterType& argToFilter, argToFilterList)
-    {
+  {
     appArguments.addArgumentToFilter(argToFilter);
-    }
+  }
 
   QCOMPARE(appArguments.arguments(QFlags<ctkAppArguments::ArgListType>(filteringOption)).count(),
            expectedArgumentCount);
@@ -268,9 +268,9 @@ void ctkAppArgumentsTester::testAddArgumentToFilter()
   QVERIFY(appArguments.argumentToFilterList().isEmpty());
 
   foreach(const ArgToFilterType& argToFilter, argToFilterList)
-    {
+  {
     appArguments.addArgumentToFilter(argToFilter);
-    }
+  }
   QCOMPARE(appArguments.argumentToFilterList(), expectedArgToFilterList);
 }
 

--- a/Base/Testing/Cpp/ctkAppLauncherEnvironmentTest.cpp
+++ b/Base/Testing/Cpp/ctkAppLauncherEnvironmentTest.cpp
@@ -45,15 +45,15 @@ void ctkAppLauncherEnvironmentTester::cleanup()
 {
   // Remove additional variables
   foreach(const QString& varName, this->VariableNames)
-    {
+  {
     this->unsetEnv(varName);
-    }
+  }
   // Reset original values
   QStringList originalEnvKeys = ctkAppLauncherEnvironment::envKeys(this->OriginalEnv);
   foreach(const QString& varName, originalEnvKeys)
-    {
+  {
     qputenv(varName.toLocal8Bit(), this->OriginalEnv.value(varName).toLocal8Bit());
-    }
+  }
 }
 
 // ----------------------------------------------------------------------------
@@ -110,13 +110,13 @@ void ctkAppLauncherEnvironmentTester::testEnvironment_data()
 
   QStringList sysEnvKeys;
   foreach (const QString& pair, sysEnv.toStringList())
-    {
+  {
     if (pair.startsWith("="))
-      {
+    {
       continue;
-      }
-    sysEnvKeys.append(pair.split("=").first());
     }
+    sysEnvKeys.append(pair.split("=").first());
+  }
 
   QTest::addColumn<QProcessEnvironment>("env");
   QTest::addColumn<QProcessEnvironment>("expectedEnv");
@@ -145,15 +145,15 @@ void ctkAppLauncherEnvironmentTester::testEnvironment_data()
   env.insert("APPLAUNCHER_LEVEL", "1");
   env.insert("APPLAUNCHER_0_FOO", "foo-level-0");
   foreach(const QString& varname, sysEnvKeys)
-    {
+  {
     env.insert(QString("APPLAUNCHER_0_%1").arg(varname), sysEnv.value(varname));
-    }
+  }
 
   QProcessEnvironment expectedEnv;
   foreach(const QString& varname, sysEnvKeys)
-    {
+  {
     expectedEnv.insert(varname, sysEnv.value(varname));
-    }
+  }
   expectedEnv.insert("FOO", "foo-level-0");
 
   QTest::newRow("APPLAUNCHER_LEVEL=1, requested 0") << env << expectedEnv << 0;
@@ -164,27 +164,27 @@ void ctkAppLauncherEnvironmentTester::testEnvironment_data()
   env.insert("APPLAUNCHER_LEVEL", "2");
   env.insert("APPLAUNCHER_0_FOO", "foo-level-0");
   foreach(const QString& varname, sysEnvKeys)
-    {
+  {
     env.insert(QString("APPLAUNCHER_0_%1").arg(varname), sysEnv.value(varname));
-    }
+  }
   env.insert("APPLAUNCHER_1_FOO", "foo-level-1");
   foreach(const QString& varname, sysEnvKeys)
-    {
+  {
     env.insert(QString("APPLAUNCHER_1_%1").arg(varname), sysEnv.value(varname));
-    }
+  }
 
   QProcessEnvironment expectedEnv;
   foreach(const QString& varname, sysEnvKeys)
-    {
+  {
     expectedEnv.insert(varname, sysEnv.value(varname));
-    }
+  }
   expectedEnv.insert("APPLAUNCHER_LEVEL", "1");
   expectedEnv.insert("APPLAUNCHER_0_FOO", "foo-level-0");
   expectedEnv.insert("FOO", "foo-level-1");
   foreach(const QString& varname, sysEnvKeys)
-    {
+  {
     expectedEnv.insert(QString("APPLAUNCHER_0_%1").arg(varname), sysEnv.value(varname));
-    }
+  }
 
   QTest::newRow("APPLAUNCHER_LEVEL=2, requested 1") << env << expectedEnv << 1;
   }
@@ -199,9 +199,9 @@ void ctkAppLauncherEnvironmentTester::testEnvironment()
 
   // Update current environment
   foreach(const QString& varName, ctkAppLauncherEnvironment::envKeys(env))
-    {
+  {
     this->setEnv(varName, env.value(varName));
-    }
+  }
 
   QProcessEnvironment requestedEnv =
       ctkAppLauncherEnvironment::environment(requestedLevel);

--- a/Base/Testing/Cpp/ctkAppLauncherSettingsTest.cpp
+++ b/Base/Testing/Cpp/ctkAppLauncherSettingsTest.cpp
@@ -152,9 +152,9 @@ void ctkAppLauncherSettingsTester::testReadSettings()
   QTemporaryFile regularSettingFile("regularSettings");
   regularSettingFile.setAutoRemove(false);
   if (!regularSettingFile.open())
-    {
+  {
     QFAIL("Failed to open settings file");
-    }
+  }
 
   // user additional settings
   bool success = true;
@@ -171,9 +171,9 @@ void ctkAppLauncherSettingsTester::testReadSettings()
   QTemporaryFile additionalSettingFile("additionalSettings/additionalSettings");
   additionalSettingFile.setAutoRemove(false);
   if (!additionalSettingFile.open())
-    {
+  {
     QFAIL("Failed to open additional settings file");
-    }
+  }
 
   // write regular settings
   {

--- a/Base/Testing/Cpp/ctkAppLauncherTest1.cpp
+++ b/Base/Testing/Cpp/ctkAppLauncherTest1.cpp
@@ -39,9 +39,9 @@ void ctkAppLauncherTest1er::testSetArguments()
   ctkAppLauncher appLauncher(*qApp);
 
   if (shouldSetArguments)
-    {
+  {
     appLauncher.setArguments(argumentsToSet);
-    }
+  }
 
   QCOMPARE(appLauncher.arguments(), expectedArguments);
 }

--- a/Base/Testing/Cpp/ctkAppLauncherTestingHelper.cpp
+++ b/Base/Testing/Cpp/ctkAppLauncherTestingHelper.cpp
@@ -18,20 +18,20 @@ bool CheckStringList(int line, const QString& description,
 {
   QString testName("CheckStringList");
   if (current.count() != expected.count())
-    {
+  {
     QStringList shorterList(expected);
     QStringList longerList(current);
     QString status("contains extra");
     if (current.count() < expected.count())
-      {
+    {
       longerList = expected;
       shorterList = current;
       status = "is missing";
-      }
+    }
     foreach (const QString& name, shorterList)
-      {
+    {
       longerList.removeOne(name);
-      }
+    }
     qWarning() << "\nLine " << line << " - " << description
                << " : " << testName << " failed"
                << "\nCompared lists have different sizes."
@@ -39,7 +39,7 @@ bool CheckStringList(int line, const QString& description,
                << "\n\texpected size:" << expected.count()
                << "\n\tcurrent list" << qPrintable(status) << "values:" << longerList;
     return false;
-    }
+  }
   QStringList sortedCurrent(current);
   sortedCurrent.sort();
 
@@ -47,9 +47,9 @@ bool CheckStringList(int line, const QString& description,
   sortedExpected.sort();
 
   for (int idx = 0; idx < sortedCurrent.count(); ++idx)
-    {
+  {
     if (sortedCurrent.at(idx) != sortedExpected.at(idx))
-      {
+    {
       qWarning() << "\nLine " << line << " - " << description
                  << " : " << testName << " failed"
                  << "\nCompared lists differ at index " << idx
@@ -59,8 +59,8 @@ bool CheckStringList(int line, const QString& description,
                  << "\n\tcurrent list values:\n\t\t" << sortedCurrent.join("\n\t\t")
                  << "\n\texpected list values:\n\t\t" << sortedExpected.join("\n\t\t");
       return false;
-      }
     }
+  }
   return true;
 }
 
@@ -73,21 +73,21 @@ bool CheckString(int line, const QString& description,
 
   bool different = true;
   if (current == 0 || expected == 0)
-    {
+  {
     different = !(current == 0 && expected == 0);
-    }
+  }
   else if(strcmp(current, expected) == 0)
-    {
+  {
     different = false;
-    }
+  }
   if(different == errorIfDifferent)
-    {
+  {
     qWarning() << "\nLine " << line << " - " << description
                << " : " << testName << "  failed"
                << "\n\tcurrent :" << (current ? current : "<null>")
                << "\n\texpected:" << (expected ? expected : "<null>");
     return false;
-    }
+  }
   return true;
 }
 
@@ -104,10 +104,10 @@ QString readFile(int line, const QString& filePath)
 {
   QFile file(filePath);
   if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
-    {
+  {
     qWarning() << "Line" << line << "- Failed to open file for reading" << QDir::current().filePath(filePath);
     return QString::null;
-    }
+  }
   QTextStream stream(&file);
   return stream.readAll();
 }
@@ -117,10 +117,10 @@ int writeFile(int line, const QString& filePath, const QString& content)
 {
   QFile file(filePath);
   if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
-    {
+  {
     qWarning() << "Line" << line << "- Failed to open file for writing" << QDir::current().filePath(filePath);
     return EXIT_FAILURE;
-    }
+  }
   QTextStream stream(&file);
   stream << content;
   return EXIT_SUCCESS;
@@ -130,31 +130,31 @@ int writeFile(int line, const QString& filePath, const QString& content)
 QString createUserAdditionalLauncherSettings(const QString& appNameTemplate, QString& appName, bool& ok)
 {
   if (!appNameTemplate.contains("XXXXXX"))
-    {
+  {
     qWarning() << "Line" << __LINE__ << "- Application template name is expected to contain 'XXXXXX'" << appNameTemplate;
     ok = false;
     return QString();
-    }
+  }
 
   // Get additional settings directory
   QDir userAdditionalSettingsDir = QFileInfo(QSettings().fileName()).dir();
 
   // Make setting directory
   if (!QDir().mkpath(userAdditionalSettingsDir.path()))
-    {
+  {
     qWarning() << "Line" << __LINE__ << "- Failed to create directory" << userAdditionalSettingsDir.path();
     ok = false;
     return QString();
-    }
+  }
   // Generate temporary settings file
   QTemporaryFile userAdditionalSettingsFile(userAdditionalSettingsDir.filePath(QString("%1.ini").arg(appNameTemplate)));
   userAdditionalSettingsFile.setAutoRemove(false);
   if (!userAdditionalSettingsFile.open())
-    {
+  {
     qWarning() << "Line" << __LINE__ << "- Failed to open temporary file" << userAdditionalSettingsFile.fileName();
     ok = false;
     return QString();
-    }
+  }
 
   // Extract unique application name of the form "AwesomeAppXXXXXX"
   appName = QFileInfo(userAdditionalSettingsFile.fileName()).fileName().split("-").at(0);

--- a/Base/Testing/Cpp/ctkAppLauncherTestingHelper.h
+++ b/Base/Testing/Cpp/ctkAppLauncherTestingHelper.h
@@ -38,9 +38,9 @@ QString createUserAdditionalLauncherSettings(const QString& appNameTemplate, QSt
   QStringList a = (actual); \
   QStringList e = (expected); \
   if (!CheckStringList(__LINE__,#actual " != " #expected, a, e)) \
-    { \
+  { \
     return EXIT_FAILURE; \
-    } \
+  } \
   }
 
 //----------------------------------------------------------------------------
@@ -50,9 +50,9 @@ QString createUserAdditionalLauncherSettings(const QString& appNameTemplate, QSt
   QStringList a = (actual); \
   QStringList e = (expected); \
   if (!CheckStringList(__LINE__,#actual " != " #expected, a, e)) \
-    { \
+  { \
     QFAIL(""); \
-    } \
+  } \
   }
 
 //----------------------------------------------------------------------------
@@ -62,9 +62,9 @@ QString createUserAdditionalLauncherSettings(const QString& appNameTemplate, QSt
   QString a = (actual); \
   QString e = (expected); \
   if (!CheckString(__LINE__,#actual " != " #expected, qPrintable(a), qPrintable(e))) \
-    { \
+  { \
     return EXIT_FAILURE; \
-    } \
+  } \
   }
 
 //----------------------------------------------------------------------------
@@ -72,9 +72,9 @@ QString createUserAdditionalLauncherSettings(const QString& appNameTemplate, QSt
 #define CHECK_INT(actual, expected) \
   { \
   if (!CheckInt(__LINE__,#actual " != " #expected, (actual), (expected))) \
-    { \
+  { \
     return EXIT_FAILURE; \
-    } \
+  } \
   }
 
 //----------------------------------------------------------------------------
@@ -82,9 +82,9 @@ QString createUserAdditionalLauncherSettings(const QString& appNameTemplate, QSt
 #define CHECK_BOOL(actual, expected) \
   { \
   if (!CheckInt(__LINE__,#actual " != " #expected, (actual)?1:0, (expected)?1:0)) \
-    { \
+  { \
     return EXIT_FAILURE; \
-    } \
+  } \
   }
 
 //----------------------------------------------------------------------------
@@ -92,11 +92,11 @@ QString createUserAdditionalLauncherSettings(const QString& appNameTemplate, QSt
   { \
   int a = (actual); \
   if (a != EXIT_SUCCESS) \
-    { \
+  { \
     qWarning() << "\nLine " << __LINE__ << " - " << #actual " != EXIT_SUCCESS" \
              << " : " << "CheckExitSuccess" << "  failed"; \
     return EXIT_FAILURE; \
-    } \
+  } \
   }
 
 //----------------------------------------------------------------------------
@@ -104,11 +104,11 @@ QString createUserAdditionalLauncherSettings(const QString& appNameTemplate, QSt
   { \
   QString a = (actual); \
   if (a.isNull()) \
-    { \
+  { \
     qWarning() << "\nLine " << __LINE__ << " - " << #actual " is Null" \
              << " : " << "CheckQStringNotNull" << "  failed"; \
     return EXIT_FAILURE; \
-    } \
+  } \
   }
 
 #include "ctkAppLauncherTestingHelper.txx"

--- a/Base/Testing/Cpp/ctkAppLauncherTestingHelper.txx
+++ b/Base/Testing/Cpp/ctkAppLauncherTestingHelper.txx
@@ -11,7 +11,7 @@ bool CheckList(int line, const QString& description,
 {
   QString msg;
   if (current.count() != expected.count())
-    {
+  {
     qWarning() << "\nLine " << line << " - " << description
                << " : " << testName << " failed"
                << "\nCompared lists have different sizes."
@@ -20,11 +20,11 @@ bool CheckList(int line, const QString& description,
                << "\n\tcurrent:" << current
                << "\n\texpected:" << expected;
     return false;
-    }
+  }
   for (int idx = 0; idx < current.count(); ++idx)
-    {
+  {
     if (current.at(idx) != expected.at(idx))
-      {
+    {
       qWarning() << "\nLine " << line << " - " << description
                  << " : " << testName << " failed"
                  << "\nCompared lists differ at index " << idx
@@ -33,8 +33,8 @@ bool CheckList(int line, const QString& description,
                  << "\n\tcurrent:" << current
                  << "\n\texpected:" << expected;
       return false;
-      }
     }
+  }
   return true;
 }
 
@@ -48,26 +48,26 @@ bool Check(int line, const QString& description,
 {
   QString testName = _testName.isEmpty() ? "Check" : _testName;
   if (errorIfDifferent)
-    {
+  {
     if(current != expected)
-      {
+    {
       qWarning() << "\nLine " << line << " - " << description
                  << " : " << testName << " failed"
                  << "\n\tcurrent :" << current
                  << "\n\texpected:" << expected;
       return false;
-      }
     }
+  }
   else
-    {
+  {
     if(current == expected)
-      {
+    {
       qWarning() << "\nLine " << line << " - " << description
                  << " : " << testName << " failed"
                  << "\n\tcurrent :" << current
                  << "\n\texpected to be different from:" << expected;
       return false;
-      }
     }
+  }
   return true;
 }

--- a/Base/Testing/Cpp/ctkCommandLineParserTest1.cpp
+++ b/Base/Testing/Cpp/ctkCommandLineParserTest1.cpp
@@ -21,20 +21,20 @@ int ctkCommandLineParserTest1(int, char*[])
   bool ok = false;
   parser1.parseArguments(arguments1, &ok);
   if (!ok)
-    {
+  {
     qCritical() << "Test1 - Failed to parse arguments";
     return EXIT_FAILURE;
-    }
+  }
 
   QStringList expectedUnparsedArguments1;
   expectedUnparsedArguments1 << "--test-bool" << "--test-string" << "ctkrocks";
 
   if (parser1.unparsedArguments() != expectedUnparsedArguments1)
-    {
+  {
     qCritical() << "unparsedArguments:" << parser1.unparsedArguments();
     qCritical() << "expectedUnparsedArguments1:" << expectedUnparsedArguments1;
     return EXIT_FAILURE;
-    }
+  }
 
   // Test2 - Check if addArgument() for a boolean works as expected
   QStringList arguments2;
@@ -47,26 +47,26 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   QHash<QString, QVariant> parsedArgs = parser2.parseArguments(arguments2, &ok);
   if (!ok)
-    {
+  {
     qCritical() << "Test2 - Failed to parse arguments";
     return EXIT_FAILURE;
-    }
+  }
 
   QStringList expectedUnparsedArguments2;
   expectedUnparsedArguments2 << "--test-string" << "ctkrocks";
 
   if (parser2.unparsedArguments() != expectedUnparsedArguments2)
-    {
+  {
     qCritical() << "Test2 - Failed - unparsedArguments:" << parser2.unparsedArguments()
         << ", expectedUnparsedArguments2:" << expectedUnparsedArguments2;
     return EXIT_FAILURE;
-    }
+  }
 
   if (parsedArgs["--test-bool"].isNull() || !parsedArgs["--test-bool"].toBool())
-    {
+  {
     qCritical() << "Test2 - Failed to parse --test-bool";
     return EXIT_FAILURE;
-    }
+  }
 
   // Test3 - check if adding QString, int, and QStringList arguments works
   QStringList arguments3;
@@ -84,43 +84,43 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   parsedArgs = parser3.parseArguments(arguments3, &ok);
   if (!ok)
-    {
+  {
     qCritical() << "Test3 - Failed to parse arguments";
     return EXIT_FAILURE;
-    }
+  }
 
   QString expectedTestString = "TestingIsGood";
   if (parsedArgs["--test-string"].toString() != expectedTestString)
-    {
+  {
     qCritical() << "Test3 - Failed - testString" << parsedArgs["--test-string"].toString()
         << ", expectedTestString" << expectedTestString;
     return EXIT_FAILURE;
-    }
+  }
 
   QString expectedTestString2 = "CTKSuperRocks";
   if (parsedArgs["--test-string2"].toString() != expectedTestString2)
-    {
+  {
     qCritical() << "Test3 - Failed - testString2" << parsedArgs["--test-string2"].toString()
         << ", expectedTestString2" << expectedTestString2;
     return EXIT_FAILURE;
-    }
+  }
 
   int expectedTestInteger = -3;
   if (parsedArgs["--test-integer"].toInt() != expectedTestInteger)
-    {
+  {
     qCritical() << "Test3 - Failed - testInteger" << parsedArgs["--test-integer"].toInt()
         << ", expectedTestInteger" << expectedTestInteger;
     return EXIT_FAILURE;
-    }
+  }
 
   QStringList expectedTestStringlist;
   expectedTestStringlist << "item1" << "item2" << "item3";
   if (parsedArgs["--test-stringlist"].toStringList() != expectedTestStringlist)
-    {
+  {
     qCritical() << "Test3 - Failed - testStringlist" << parsedArgs["--test-stringlist"].toStringList()
         << ", expectedTestStringlist" << expectedTestStringlist;
     return EXIT_FAILURE;
-    }
+  }
 
   // Test4 - check if helpText() works as expected
   ctkCommandLineParser parser4;
@@ -137,11 +137,11 @@ int ctkCommandLineParserTest1(int, char*[])
                            << "  -hs3.......................This is an help string too for sure !?\n";
 
   if (expectedHelpString != parser4.helpText('.'))
-    {
+  {
     qCritical() << "Test4 - Problem with helpText('.') - helpText:\n" << parser4.helpText('.')
         << ", expectedHelpString:\n" << expectedHelpString;
     return EXIT_FAILURE;
-    }
+  }
 
   QString expectedHelpString2;
   QTextStream streamExpectedHelpString2(&expectedHelpString2);
@@ -150,50 +150,50 @@ int ctkCommandLineParserTest1(int, char*[])
                             << "  -hs2, --help-string-long   This is an help string too !\n"
                             << "  -hs3                       This is an help string too for sure !?\n";
   if (expectedHelpString2 != parser4.helpText())
-    {
+  {
     qCritical() << "Test4 - Problem with helpText() - helpText:\n" << parser4.helpText()
         << ", expectedHelpString2:\n" << expectedHelpString2;
     return EXIT_FAILURE;
-    }
+  }
 
   // Test5 - check if setExactMatchRegularExpression() works as expected
   ctkCommandLineParser parser5;
 
   if (parser5.setExactMatchRegularExpression("--unknown",".*", "invalid"))
-    {
+  {
     qCritical() << "Test5 - Problem with setExactMatchRegularExpression(shortOrLongArg) - "
                    "The function should return false if an invalid argument is passed";
     return EXIT_FAILURE;
-    }
+  }
 
   parser5.addArgument("--list", "", QVariant::StringList, "Test5 list");
   if (!parser5.setExactMatchRegularExpression("--list","item[0-9]",
                                               "Element of the form item[0-9] are expected."))
-    {
+  {
     qCritical() << "Test5 - Problem with setExactMatchRegularExpression(StringListArg)";
     return EXIT_FAILURE;
-    }
+  }
   parser5.addArgument("--string", "", QVariant::String, "Test5 string");
   if (!parser5.setExactMatchRegularExpression("--string","ctkStop|ctkStart",
                                               "ctkStop or ctkStart is expected."))
-    {
+  {
     qCritical() << "Test5 - Problem with setExactMatchRegularExpression(StringArg)";
     return EXIT_FAILURE;
-    }
+  }
   parser5.addArgument("--bool", "", QVariant::Bool, "Test5 bool");
   if (parser5.setExactMatchRegularExpression("--bool",".*", "invalid"))
-    {
+  {
     qCritical() << "Test5 - Problem with setExactMatchRegularExpression(BooleanArg) - "
                    "The function should return false if a boolean argument is passed";
     return EXIT_FAILURE;
-    }
+  }
   parser5.addArgument("--int", "", QVariant::Int, "Test5 int");
   if (!parser5.setExactMatchRegularExpression("--int","[1-3]",
                                               "Value 1, 2 or 3 is expected."))
-    {
+  {
     qCritical() << "Test5 - Problem with setExactMatchRegularExpression(IntegerArg)";
     return EXIT_FAILURE;
-    }
+  }
 
   QStringList arguments5;
   arguments5 << "ctkCommandLineParserTest1";
@@ -204,10 +204,10 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   parser5.parseArguments(arguments5, &ok);
   if (!ok)
-    {
+  {
     qCritical() << "Test5 - Failed to parse arguments";
     return EXIT_FAILURE;
-    }
+  }
 
   arguments5.clear();
   arguments5 << "ctkCommandLineParserTest1";
@@ -218,21 +218,21 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   parser5.parseArguments(arguments5, &ok);
   if (ok)
-    {
+  {
     qCritical() << "Test5 - parseArguments() should return False - 'ctkStopp' isn't a valid string";
     return EXIT_FAILURE;
-    }
+  }
 
   QString expectedErrorString =
     "Value(s) associated with argument --string are incorrect."
     " ctkStop or ctkStart is expected.";
 
   if(expectedErrorString != parser5.errorString())
-    {
+  {
     qCritical() << "Test5 - Failed - expectedErrorString" << expectedErrorString
             << ", parser5.errorString()" << parser5.errorString();
     return EXIT_FAILURE;
-    }
+  }
 
   arguments5.clear();
   arguments5 << "ctkCommandLineParserTest1";
@@ -243,21 +243,21 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   parser5.parseArguments(arguments5, &ok);
   if (ok)
-    {
+  {
     qCritical() << "Test5 - parseArguments() should return False - '4' isn't a valid int";
     return EXIT_FAILURE;
-    }
+  }
 
   QString expectedErrorString2 =
     "Value(s) associated with argument --int are incorrect."
     " Value 1, 2 or 3 is expected.";
 
   if(expectedErrorString2 != parser5.errorString())
-    {
+  {
     qCritical() << "Test5 - Failed - expectedErrorString2" << expectedErrorString2
             << ", parser5.errorString()" << parser5.errorString();
     return EXIT_FAILURE;
-    }
+  }
 
   arguments5.clear();
   arguments5 << "ctkCommandLineParserTest1";
@@ -268,22 +268,22 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   parser5.parseArguments(arguments5, &ok);
   if (ok)
-    {
+  {
     qCritical() << "Test5 - parseArguments() should return False "
                    "- 'item10' isn't a valid list element";
     return EXIT_FAILURE;
-    }
+  }
 
   QString expectedErrorString3 =
     "Value(s) associated with argument --list are incorrect."
     " Element of the form item[0-9] are expected.";
 
   if(expectedErrorString3 != parser5.errorString())
-    {
+  {
     qCritical() << "Test5 - Failed - expectedErrorString3" << expectedErrorString3
             << ", parser5.errorString()" << parser5.errorString();
     return EXIT_FAILURE;
-    }
+  }
 
   // Test6 - Check if the parser handle the case when value of parameter is omitted
   ctkCommandLineParser parser6;
@@ -298,10 +298,10 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   parser6.parseArguments(arguments6, &ok);
   if (ok)
-    {
+  {
     qCritical() << "Test6 - Problem with parseArguments()";
     return EXIT_FAILURE;
-    }
+  }
 
   // Expected ignore argument for Test7, 8. 9 and 10
   QStringList expectedUnparsedArguments;
@@ -320,24 +320,24 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   parsedArgs = parser7.parseArguments(arguments7, &ok);
   if (!ok)
-    {
+  {
     qCritical() << "Test7 - Failed to parse arguments";
     return EXIT_FAILURE;
-    }
+  }
   bool expectedTest7Bool = true;
   if (parsedArgs["--bool"].toBool() != expectedTest7Bool)
-    {
+  {
     qCritical() << "Test7 - Failed - test7Bool" << test7Bool
         << ", expectedTest7Bool" << expectedTest7Bool;
     return EXIT_FAILURE;
-    }
+  }
 
   if (parser7.unparsedArguments() != expectedUnparsedArguments)
-    {
+  {
     qCritical() << "Test7 - Failed - expectedUnparsedArguments " << expectedUnparsedArguments
                 << ", parser7.unparsedArguments" << parser7.unparsedArguments();
     return EXIT_FAILURE;
-    }
+  }
 
   // Test7b - Same as Test7 using
   ctkCommandLineParser parser7b;
@@ -352,25 +352,25 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   parsedArgs = parser7b.parseArguments(arguments7b, &ok);
   if (!ok)
-    {
+  {
     qCritical() << "Test7b - Failed to parse arguments";
     return EXIT_FAILURE;
-    }
+  }
   bool expectedTest7bBool = true;
   bool test7bBool = parsedArgs["--bool"].toBool();
   if (test7bBool != expectedTest7bBool)
-    {
+  {
     qCritical() << "Test7b - Failed - test7bBool" << test7bBool
         << ", expectedTest7bBool" << expectedTest7bBool;
     return EXIT_FAILURE;
-    }
+  }
 
   if (parser7b.unparsedArguments() != expectedUnparsedArguments)
-    {
+  {
     qCritical() << "Test7b - Failed - expectedUnparsedArguments " << expectedUnparsedArguments
                 << ", parser7b.unparsedArguments" << parser7b.unparsedArguments();
     return EXIT_FAILURE;
-    }
+  }
 
   // Test8 - Check if addStringArgument and ignore_rest=true works as expected
   ctkCommandLineParser parser8;
@@ -385,25 +385,25 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   parsedArgs = parser8.parseArguments(arguments8, &ok);
   if (!ok)
-    {
+  {
     qCritical() << "Test8 - Failed to parse arguments";
     return EXIT_FAILURE;
-    }
+  }
 
   QString expectedTest8String = "ctk";
   if (parsedArgs["--string"].toString() != expectedTest8String)
-    {
+  {
     qCritical() << "Test8 - Failed - test8String" << parsedArgs["--string"].toString()
         << ", expectedTest8String" << expectedTest8String;
     return EXIT_FAILURE;
-    }
+  }
 
   if (parser8.unparsedArguments() != expectedUnparsedArguments)
-    {
+  {
     qCritical() << "Test8 - Failed - expectedUnparsedArguments " << expectedUnparsedArguments
                 << ", parser8.unparsedArguments" << parser8.unparsedArguments();
     return EXIT_FAILURE;
-    }
+  }
 
   // Test9 - Check if addArgument for int and ignore_rest=true works as expected
   ctkCommandLineParser parser9;
@@ -418,25 +418,25 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   parsedArgs = parser9.parseArguments(arguments9, &ok);
   if (!ok)
-    {
+  {
     qCritical() << "Test9 - Failed to parse arguments";
     return EXIT_FAILURE;
-    }
+  }
 
   int expectedTest9Int = 74;
   if (parsedArgs["--integer"].toInt() != expectedTest9Int)
-    {
+  {
     qCritical() << "Test9 - Failed - test9Int" << parsedArgs["--integer"].toInt()
         << ", expectedTest9Int" << expectedTest9Int;
     return EXIT_FAILURE;
-    }
+  }
 
   if (parser9.unparsedArguments() != expectedUnparsedArguments)
-    {
+  {
     qCritical() << "Test9 - Failed - expectedUnparsedArguments " << expectedUnparsedArguments
                 << ", parser9.unparsedArguments" << parser9.unparsedArguments();
     return EXIT_FAILURE;
-    }
+  }
 
   // Test10 - Check if argumentParsed works as expected
   ctkCommandLineParser parser10;
@@ -444,10 +444,10 @@ int ctkCommandLineParserTest1(int, char*[])
 
   // Since parseArguments hasn't been called, argumentParsed should return False
   if(parser10.argumentParsed("--bool"))
-    {
+  {
     qCritical() << "Test10 - Problem with argumentParsed() - Should return False";
     return EXIT_FAILURE;
-    }
+  }
 
   QStringList arguments10;
   arguments10 << "ctkCommandLineParserTest1";
@@ -456,23 +456,23 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   parser10.parseArguments(arguments10, &ok);
   if (!ok)
-    {
+  {
     qCritical() << "Test10 - Failed to parse arguments.";
     return EXIT_FAILURE;
-    }
+  }
 
   if(parser10.argumentParsed("--bool-notadded"))
-    {
+  {
     qCritical() << "Test10 - Problem with argumentParsed() - "
                    "Should return False since argument '--bool-notadded' hasn't been added.";
     return EXIT_FAILURE;
-    }
+  }
 
   if(!parser10.argumentParsed("--bool"))
-    {
+  {
     qCritical() << "Test10 - Problem with argumentParsed() - Should return True";
     return EXIT_FAILURE;
-    }
+  }
 
   // Test11 - Check if setArgumentPrefix works as expected
   ctkCommandLineParser parser11;
@@ -489,36 +489,36 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   parsedArgs = parser11.parseArguments(arguments11, &ok);
   if (!ok)
-    {
+  {
     qCritical() << "Test11 - Failed to parse arguments: " << parser11.errorString();
     return EXIT_FAILURE;
-    }
+  }
 
   if (!parser11.unparsedArguments().contains("test-string"))
-    {
+  {
     qCritical() << "Test11 - argument test-string should be unknown.";
     return EXIT_FAILURE;
-    }
+  }
 
   if (!parser11.argumentParsed("test-string") || !parser11.argumentParsed("i"))
-    {
+  {
     qCritical() << "Test11 - Problem with argumentParsed().";
     return EXIT_FAILURE;
-    }
+  }
 
   if (parsedArgs["test-string"].toString() != "Unix-style")
-    {
+  {
     qCritical() << "Test11 - Failed argument: test-string, got: " << parsedArgs["test-string"].toString()
         << ", expected: " << "Unix-style";
     return EXIT_FAILURE;
-    }
+  }
 
   if (parsedArgs["i"].toInt() != 5)
-    {
+  {
     qCritical() << "Test11 - Failed argument: i, got: " << parsedArgs["i"].toInt()
         << ", expected: " << 5;
     return EXIT_FAILURE;
-    }
+  }
 
   // Test12 - Check if the returned hash map contains the correct entries
   ctkCommandLineParser parser12;
@@ -529,34 +529,34 @@ int ctkCommandLineParserTest1(int, char*[])
 
   parsedArgs = parser12.parseArguments(arguments12);
   if (!parsedArgs.isEmpty())
-    {
+  {
     qCritical() << "Test12 - Returned hash map should be empty.";
     return EXIT_FAILURE;
-    }
+  }
 
   arguments12 << "--test-list" << "--test-list2";
   parsedArgs = parser12.parseArguments(arguments12);
   if (parsedArgs.size() != 1 || !parsedArgs.contains("--test-list"))
-    {
+  {
     qCritical() << "Test12 - Returned hash map contains wrong elements.";
     return EXIT_FAILURE;
-    }
+  }
 
   // Test13 - Check that supplying a default value works
   ctkCommandLineParser parser13;
   parser13.addArgument("", "-d", QVariant::Int, "Argument with default value", 3);
   parsedArgs = parser13.parseArguments(QStringList(), &ok);
   if (!parsedArgs.contains("-d"))
-    {
+  {
     qCritical() << "Test13 - Returned hash map does not contain argument with default value.";
     return EXIT_FAILURE;
-    }
+  }
 
   if (parsedArgs["-d"].toInt() != 3)
-    {
+  {
     qCritical() << "Test13 - Returned hash map contains wrong argument parameter.";
     return EXIT_FAILURE;
-    }
+  }
 
   // ==================== QSettings tests ====================
   QSettings::setDefaultFormat(QSettings::IniFormat);
@@ -581,10 +581,10 @@ int ctkCommandLineParserTest1(int, char*[])
 
   //  Check that QSettings are ignored
   if (parsedArgs.size() != 1 || parsedArgs["s"] != "short")
-    {
+  {
     qCritical() << "Test14 - Parsed arguments must only contain -s short.";
     return EXIT_FAILURE;
-    }
+  }
 
   // Now use QSettings
   parser14.enableSettings("disable-settings");
@@ -592,57 +592,57 @@ int ctkCommandLineParserTest1(int, char*[])
   parsedArgs = parser14.parseArguments(arguments14);
 
   if (!parser14.settingsEnabled())
-    {
+  {
     qCritical() << "Test14 - Disabling settings failed.";
     return EXIT_FAILURE;
-    }
+  }
 
   if (parser14.unparsedArguments().size() != 1 ||
       !parser14.unparsedArguments().contains("unknown"))
-    {
+  {
     qCritical() << "Test14 - Parsing unknown arguments failed.";
     return EXIT_FAILURE;
-    }
+  }
 
   if (parsedArgs.contains("invalid"))
-    {
+  {
     qCritical() << "Test14 - Invalid QSettings value found.";
     return EXIT_FAILURE;
-    }
+  }
 
   if (parsedArgs.size() != 2)
-    {
+  {
     qCritical() << "Test14 - Wrong number of parsed arguments.";
     return EXIT_FAILURE;
-    }
+  }
 
   if (parsedArgs["s"] != "short")
-    {
+  {
     qCritical() << "Test14 - QSettings values must not overwrite user values.";
     return EXIT_FAILURE;
-    }
+  }
 
   if (parsedArgs["long-settings-argument"].toInt() != 5)
-    {
+  {
     qCritical() << "Test14 - Missing value from QSettings.";
     return EXIT_FAILURE;
-    }
+  }
 
   arguments14.clear();
   arguments14 << "ctkCommandLineParserTest1";
   parsedArgs = parser14.parseArguments(arguments14);
 
   if (parsedArgs.size() != 2)
-    {
+  {
     qCritical() << "Test14 - Only QSettings values corresponding to arguments must be included.";
     return EXIT_FAILURE;
-    }
+  }
 
   if (parsedArgs["s"] != "settings-short")
-    {
+  {
     qCritical() << "Test14 - QSettings value should be used as default parameter.";
     return EXIT_FAILURE;
-    }
+  }
 
   // Disable QSettings via command line argument
   arguments14.clear();
@@ -653,17 +653,17 @@ int ctkCommandLineParserTest1(int, char*[])
   parsedArgs = parser14.parseArguments(arguments14);
 
   if (parsedArgs["long-settings-argument"].toInt() != 12)
-    {
+  {
     qCritical() << "Test14 - Wrong parameter for argument: long-settings-argument.";
     return EXIT_FAILURE;
-    }
+  }
 
   if (parsedArgs["s"] != "my-short")
-    {
+  {
     qCritical() << parsedArgs;
     qCritical() << "Test14 - Default value for argument -s not used.";
     return EXIT_FAILURE;
-    }
+  }
 
   // Test15 - Check that merging with QSettings works
   settings.clear();
@@ -681,60 +681,60 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   parsedArgs = parser15.parseArguments(arguments15, &ok);
   if (!ok)
-    {
+  {
     qCritical() << "Test15 - parsing arguments failed.";
     return EXIT_FAILURE;
-    }
+  }
 
   if (parsedArgs.contains("--list-argument"))
-    {
+  {
     QStringList list = parsedArgs["--list-argument"].toStringList();
     if (list.size() != 3)
-      {
+    {
       qCritical() << "Test15 - Parameter merging failed.";
       return EXIT_FAILURE;
-      }
+    }
     if (!list.contains("a") || !list.contains("b") || !list.contains("z"))
-      {
+    {
       qCritical() << "Test15 - Merged list contains wrong elements.";
       return EXIT_FAILURE;
-      }
     }
+  }
   else
-    {
+  {
     qCritical() << "Test15 - --list-argument was not parsed.";
     return EXIT_FAILURE;
-    }
+  }
 
   // Test with disabled merging
   parser15.mergeSettings(false);
   ok = false;
   parsedArgs = parser15.parseArguments(arguments15, &ok);
   if (!ok)
-    {
+  {
     qCritical() << "Test15 - parsing arguments failed.";
     return EXIT_FAILURE;
-    }
+  }
 
   if (parsedArgs.contains("--list-argument"))
-    {
+  {
     QStringList list = parsedArgs["--list-argument"].toStringList();
     if (list.size() != 2)
-      {
+    {
       qCritical() << "Test15 - Disabling merging failed.";
       return EXIT_FAILURE;
-      }
+    }
     if (!list.contains("a") || !list.contains("b"))
-      {
+    {
       qCritical() << "Test15 - List contains wrong elements.";
       return EXIT_FAILURE;
-      }
     }
+  }
   else
-    {
+  {
     qCritical() << "Test15 - --list-argument was not parsed.";
     return EXIT_FAILURE;
-    }
+  }
 
   // Test16 - Check if strictMode works
   settings.clear();
@@ -752,10 +752,10 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   parsedArgs = parser16.parseArguments(arguments16, &ok);
   if (!ok)
-    {
+  {
     qCritical() << "Test16-1 - parsing arguments failed.";
     return EXIT_FAILURE;
-    }
+  }
 
   // Since two identical arguments are provided, parseArguments should fail
   arguments16.clear();
@@ -765,10 +765,10 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   parsedArgs = parser16.parseArguments(arguments16, &ok);
   if (ok)
-    {
+  {
     qCritical() << "Test16-2 - parsing arguments should fail.";
     return EXIT_FAILURE;
-    }
+  }
 
   // Since an unknown argument is provided, parseArguments should fail
   arguments16.clear();
@@ -778,10 +778,10 @@ int ctkCommandLineParserTest1(int, char*[])
   ok = false;
   parsedArgs = parser16.parseArguments(arguments16, &ok);
   if (ok)
-    {
+  {
     qCritical() << "Test16-3 - parsing arguments should fail.";
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/Base/ctkAppArguments.cpp
+++ b/Base/ctkAppArguments.cpp
@@ -48,18 +48,18 @@ void ctkChar2DArray::setValues(const QStringList& list)
   Q_D(ctkChar2DArray);
   this->clear();
   if (list.isEmpty())
-    {
+  {
     return;
-    }
+  }
   d->List = list;
   d->Count = list.count();
   d->Values = new char*[list.count()];
   for(int index = 0; index < d->List.count(); ++index)
-    {
+  {
     QString item = d->List.at(index);
     d->Values[index] = new char[item.size() + 1];
     qstrcpy(d->Values[index], item.toLocal8Bit().data());
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -67,9 +67,9 @@ void ctkChar2DArray::clear()
 {
   Q_D(ctkChar2DArray);
   for (int index = 0; index < d->List.count(); ++index)
-    {
+  {
     delete[] d->Values[index];
-    }
+  }
   delete [] d->Values;
   d->Values = 0;
   d->Count = 0;
@@ -127,14 +127,14 @@ ctkAppArgumentsPrivate::ctkAppArgumentsPrivate(int &argc, char **argv) :
 {
   static const char *const empty = "";
   if (this->Argc == 0 || this->Argv == 0)
-    {
+  {
     this->Argc = 0;
     this->Argv = const_cast<char **>(&empty);
-    }
+  }
   for(int index = 0; index < this->Argc; ++index)
-    {
+  {
     this->Arguments << this->Argv[index];
-    }
+  }
   this->filterArguments();
 }
 
@@ -150,31 +150,31 @@ void ctkAppArgumentsPrivate::filterArguments()
   this->ReservedArguments.clear();
 
   for(int index = 0; index < this->Argc; ++index)
-    {
+  {
     ctkAppArguments::ArgToFilterType argToFilter = this->findArgToFilter(this->Argv[index]);
     if (argToFilter.first.isEmpty())
-      {
+    {
       this->RegularArguments << this->Argv[index];
       continue;
-      }
+    }
     if (argToFilter.second == ctkAppArguments::ARG_TO_FILTER_NO_VALUE ||
         argToFilter.second & ctkAppArguments::ARG_TO_FILTER_EQUAL_VALUE)
-      {
+    {
       this->ReservedArguments << this->Argv[index];
       continue;
-      }
+    }
     else if (argToFilter.second & ctkAppArguments::ARG_TO_FILTER_SPACE_VALUE)
-      {
+    {
       this->ReservedArguments << this->Argv[index];
       if (index + 1 < this->Argc)
-        {
+      {
         this->ReservedArguments << this->Argv[index + 1];
         ++index;
         continue;
-        }
       }
-    Q_ASSERT(false);
     }
+    Q_ASSERT(false);
+  }
   this->RegularArgumentsAsCharStarArray.setValues(this->RegularArguments);
   this->ReservedArgumentsAsCharStarArray.setValues(this->ReservedArguments);
 }
@@ -183,35 +183,35 @@ void ctkAppArgumentsPrivate::filterArguments()
 ctkAppArguments::ArgToFilterType ctkAppArgumentsPrivate::findArgToFilter(const char* arg)
 {
   if (arg == 0)
-    {
+  {
     return ctkAppArguments::ArgToFilterType();
-    }
+  }
 
   foreach(const ctkAppArguments::ArgToFilterType& argToFilter, this->ArgToFilterList)
-    {
+  {
     if (argToFilter.second == ctkAppArguments::ARG_TO_FILTER_NO_VALUE)
-      {
+    {
       if (arg == argToFilter.first)
-        {
-        return argToFilter;
-        }
-      }
-    else if (argToFilter.second & ctkAppArguments::ARG_TO_FILTER_EQUAL_VALUE)
       {
-      if (QString(arg).startsWith(
-            argToFilter.first.endsWith("=") ? argToFilter.first : QString(argToFilter.first).append("=")))
-        {
         return argToFilter;
-        }
-      }
-    else if (argToFilter.second & ctkAppArguments::ARG_TO_FILTER_SPACE_VALUE)
-      {
-      if (arg == argToFilter.first)
-        {
-        return argToFilter;
-        }
       }
     }
+    else if (argToFilter.second & ctkAppArguments::ARG_TO_FILTER_EQUAL_VALUE)
+    {
+      if (QString(arg).startsWith(
+            argToFilter.first.endsWith("=") ? argToFilter.first : QString(argToFilter.first).append("=")))
+      {
+        return argToFilter;
+      }
+    }
+    else if (argToFilter.second & ctkAppArguments::ARG_TO_FILTER_SPACE_VALUE)
+    {
+      if (arg == argToFilter.first)
+      {
+        return argToFilter;
+      }
+    }
+  }
   return ctkAppArguments::ArgToFilterType();
 }
 
@@ -219,21 +219,21 @@ ctkAppArguments::ArgToFilterType ctkAppArgumentsPrivate::findArgToFilter(const c
 void ctkAppArgumentsPrivate::addArgumentToFilter(const ctkAppArguments::ArgToFilterType &argToFilter, bool filter)
 {
   if (argToFilter.second & ctkAppArguments::ARG_TO_FILTER_EQUAL_VALUE)
-    {
+  {
     this->ArgToFilterList << ctkAppArguments::ArgToFilterType(argToFilter.first, ctkAppArguments::ARG_TO_FILTER_EQUAL_VALUE);
-    }
+  }
   if (argToFilter.second & ctkAppArguments::ARG_TO_FILTER_SPACE_VALUE)
-    {
+  {
     this->ArgToFilterList << ctkAppArguments::ArgToFilterType(argToFilter.first, ctkAppArguments::ARG_TO_FILTER_SPACE_VALUE);
-    }
+  }
   if (argToFilter.second == ctkAppArguments::ARG_TO_FILTER_NO_VALUE)
-    {
+  {
     this->ArgToFilterList << ctkAppArguments::ArgToFilterType(argToFilter.first, ctkAppArguments::ARG_TO_FILTER_NO_VALUE);
-    }
+  }
   if (filter)
-    {
+  {
     this->filterArguments();
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -255,17 +255,17 @@ QStringList ctkAppArguments::arguments(ctkAppArguments::ArgListTypes option)cons
 {
   Q_D(const ctkAppArguments);
   if (option == ctkAppArguments::ARG_REGULAR_LIST)
-    {
+  {
     return d->RegularArguments;
-    }
+  }
   else if (option == ctkAppArguments::ARG_RESERVED_LIST)
-    {
+  {
     return d->ReservedArguments;
-    }
+  }
   else //if (option == ctkAppArguments::ARG_FULL_LIST)
-    {
+  {
     return d->Arguments;
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -273,17 +273,17 @@ char** ctkAppArguments::argumentValues(ctkAppArguments::ArgListTypes option) con
 {
   Q_D(const ctkAppArguments);
   if (option == ctkAppArguments::ARG_REGULAR_LIST)
-    {
+  {
     return d->RegularArgumentsAsCharStarArray.values();
-    }
+  }
   else if (option == ctkAppArguments::ARG_RESERVED_LIST)
-    {
+  {
     return d->ReservedArgumentsAsCharStarArray.values();
-    }
+  }
   else // if (option == ctkAppArguments::ARG_FULL_LIST)
-    {
+  {
     return d->Argv;
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -291,17 +291,17 @@ int& ctkAppArguments::argumentCount(ctkAppArguments::ArgListTypes option)
 {
   Q_D(ctkAppArguments);
   if (option == ctkAppArguments::ARG_REGULAR_LIST)
-    {
+  {
     return d->RegularArgumentsAsCharStarArray.count();
-    }
+  }
   else if (option == ctkAppArguments::ARG_RESERVED_LIST)
-    {
+  {
     return d->ReservedArgumentsAsCharStarArray.count();
-    }
+  }
   else // if (option == ctkAppArguments::ARG_FULL_LIST)
-    {
+  {
     return d->Argc;
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -324,8 +324,8 @@ void ctkAppArguments::setArgumentToFilterList(const ArgToFilterListType& list)
   Q_D(ctkAppArguments);
   d->ArgToFilterList.clear();
   foreach(const ArgToFilterType& argToFilter, list)
-    {
+  {
     d->addArgumentToFilter(argToFilter, /* filter = */ false);
-    }
+  }
   d->filterArguments();
 }

--- a/Base/ctkAppArguments.h
+++ b/Base/ctkAppArguments.h
@@ -43,11 +43,11 @@ public:
   ~ctkAppArguments();
 
   enum ArgListType
-    {
+  {
     ARG_RESERVED_LIST = 0x1,
     ARG_REGULAR_LIST = 0x2,
     ARG_FULL_LIST = ARG_RESERVED_LIST & ARG_REGULAR_LIST
-    };
+  };
   Q_DECLARE_FLAGS(ArgListTypes, ArgListType)
 
   QStringList arguments(ArgListTypes option = ARG_FULL_LIST)const;
@@ -57,11 +57,11 @@ public:
   int& argumentCount(ArgListTypes option = ARG_FULL_LIST);
 
   enum ArgToFilterOption
-    {
+  {
     ARG_TO_FILTER_NO_VALUE = 0x0,
     ARG_TO_FILTER_EQUAL_VALUE = 0x1,
     ARG_TO_FILTER_SPACE_VALUE = 0x2
-    };
+  };
   Q_DECLARE_FLAGS(ArgToFilterOptions, ArgToFilterOption)
 
   class ArgToFilterType : public QPair<QString, ArgToFilterOptions>

--- a/Base/ctkAppLauncher.cpp
+++ b/Base/ctkAppLauncher.cpp
@@ -90,38 +90,38 @@ void ctkAppLauncherPrivate::reportError(const QString& msg) const
 void ctkAppLauncherPrivate::reportInfo(const QString& msg, bool force) const
 {
   if (this->verbose() || force)
-    {
+  {
     std::cout << "info: " << qPrintable(msg) << std::endl;
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
 void ctkAppLauncherPrivate::exit(int exitCode)
 {
   if (this->Application)
-    {
+  {
     this->Application->exit(exitCode);
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
 bool ctkAppLauncherPrivate::processSplashPathArgument()
 {
   if (this->LauncherSplashImagePath.isEmpty())
-    {
+  {
     this->LauncherSplashImagePath = this->DefaultLauncherSplashImagePath;
-    }
+  }
   this->LauncherSplashImagePath = this->expandValue(this->LauncherSplashImagePath);
   this->reportInfo(QString("LauncherSplashImagePath [%1]").arg(this->LauncherSplashImagePath));
 
   // Make sure the splash image exists if a splashscreen is used
   if (!QFile::exists(this->LauncherSplashImagePath)
       && !this->disableSplash() )
-    {
+  {
     this->reportError(
       QString("SplashImage does NOT exist [%1]").arg(this->LauncherSplashImagePath));
     return false;
-    }
+  }
   return true;
 }
 
@@ -129,9 +129,9 @@ bool ctkAppLauncherPrivate::processSplashPathArgument()
 bool ctkAppLauncherPrivate::processScreenHideDelayMsArgument()
 {
   if (this->LauncherSplashScreenHideDelayMs == -1)
-    {
+  {
     this->LauncherSplashScreenHideDelayMs = this->DefaultLauncherSplashScreenHideDelayMs;
-    }
+  }
   this->reportInfo(QString("LauncherSplashScreenHideDelayMs [%1]").arg(this->LauncherSplashScreenHideDelayMs));
 
   return true;
@@ -141,13 +141,13 @@ bool ctkAppLauncherPrivate::processScreenHideDelayMsArgument()
 bool ctkAppLauncherPrivate::processAdditionalSettings()
 {
   if (this->AdditionalSettingsFilePath.isEmpty())
-    {
+  {
     return true;
-    }
+  }
   if (!QFile::exists(this->AdditionalSettingsFilePath))
-    {
+  {
     return true;
-    }
+  }
 
   ctkAppLauncherPrivate::ScopedLauncherSettingsDir scopedLauncherSettingsDir(this, Self::AdditionalSettings);
   Q_UNUSED(scopedLauncherSettingsDir);
@@ -159,16 +159,16 @@ bool ctkAppLauncherPrivate::processAdditionalSettingsArgument()
 {
   Q_Q(ctkAppLauncher);
   if (!this->ParsedArgs.contains("launcher-additional-settings"))
-    {
+  {
     return true;
-    }
+  }
   QString additionalSettings = this->ParsedArgs.value("launcher-additional-settings").toString();
   if (!QFile::exists(additionalSettings))
-    {
+  {
     this->reportError(QString("File specified using --launcher-additional-settings argument "
                               "does NOT exist ! [%1]").arg(additionalSettings));
     return false;
-    }
+  }
 
   q->setAdditionalSettingsFilePath(additionalSettings);
 
@@ -181,9 +181,9 @@ bool ctkAppLauncherPrivate::processAdditionalSettingsArgument()
 QString ctkAppLauncherPrivate::additionalSettingsDir() const
 {
   if (this->AdditionalSettingsFilePath.isEmpty())
-    {
+  {
     return QString();
-    }
+  }
   QFileInfo fileInfo(this->AdditionalSettingsFilePath);
   return fileInfo.path();
 }
@@ -192,15 +192,15 @@ QString ctkAppLauncherPrivate::additionalSettingsDir() const
 bool ctkAppLauncherPrivate::processUserAdditionalSettings()
 {
   if (this->ParsedArgs.value("launcher-ignore-user-additional-settings").toBool())
-    {
+  {
     return true;
-    }
+  }
 
   QString additionalSettings = this->findUserAdditionalSettings();
   if(additionalSettings.isEmpty())
-    {
+  {
     return true;
-    }
+  }
   this->LauncherSettingsDirs[Self::UserAdditionalSettings] = QFileInfo(additionalSettings).absolutePath();
   ctkAppLauncherPrivate::ScopedLauncherSettingsDir scopedLauncherSettingsDir(this, Self::UserAdditionalSettings);
   Q_UNUSED(scopedLauncherSettingsDir);
@@ -214,63 +214,63 @@ bool ctkAppLauncherPrivate::processApplicationToLaunchArgument()
   this->ApplicationToLaunch = this->ParsedArgs.value("launch").toString();
 
   if (!this->ExtraApplicationToLaunch.isEmpty())
-    {
+  {
     this->ApplicationToLaunch = this->ExtraApplicationToLaunch;
-    }
+  }
 
   if (this->ApplicationToLaunch.isEmpty())
-    {
+  {
     this->ApplicationToLaunch = this->DefaultApplicationToLaunch;
-    }
+  }
 
   this->ApplicationToLaunch = this->expandValue(this->ApplicationToLaunch);
 
   if (!this->ApplicationToLaunch.isEmpty())
-    {
+  {
     QFileInfo applicationToLaunchInfo(this->ApplicationToLaunch);
     if (applicationToLaunchInfo.isRelative())
-      {
+    {
       QString path = applicationToLaunchInfo.path() + "/" + applicationToLaunchInfo.baseName();
       QString extension = applicationToLaunchInfo.completeSuffix();
 #ifdef Q_OS_WIN32
       if (extension.isEmpty())
-        {
+      {
         extension = "exe";
-        }
+      }
 #endif
       QString resolvedApplicationToLaunch = this->searchPaths(path, QStringList() << extension);
       if (!resolvedApplicationToLaunch.isEmpty())
-        {
+      {
         this->ApplicationToLaunch = resolvedApplicationToLaunch;
-        }
       }
     }
+  }
 
   this->reportInfo(QString("ApplicationToLaunch [%1]").arg(this->ApplicationToLaunch));
 
   // Make sure the program to launch exists
   if (this->ApplicationToLaunch.isEmpty() || !QFile::exists(this->ApplicationToLaunch))
-    {
+  {
     this->reportError(
       QString("Application does NOT exists [%1]").arg(this->ApplicationToLaunch));
 
     if (!this->ParsedArgs.contains("launch") && !this->ValidSettingsFile)
-      {
+    {
       this->reportError("--launch argument has NOT been specified");
-      }
-    return false;
     }
+    return false;
+  }
 
   // ... and is executable
   if (!(QFile::permissions(this->ApplicationToLaunch) & QFile::ExeUser))
-    {
+  {
     this->reportError(
       QString("Application is NOT executable [%1]").arg(this->ApplicationToLaunch));
     return false;
-    }
+  }
 
   if (!this->ExtraApplicationToLaunchArguments.isEmpty())
-    {
+  {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     this->ApplicationToLaunchArguments =
         this->ExtraApplicationToLaunchArguments.split(" ", Qt::SkipEmptyParts);
@@ -278,11 +278,11 @@ bool ctkAppLauncherPrivate::processApplicationToLaunchArgument()
     this->ApplicationToLaunchArguments =
         this->ExtraApplicationToLaunchArguments.split(" ", QString::SkipEmptyParts);
 #endif
-    }
+  }
 
   // Set ApplicationToLaunchArguments with the value read from the settings file
   if (this->ApplicationToLaunchArguments.empty())
-    {
+  {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     this->ApplicationToLaunchArguments =
         this->DefaultApplicationToLaunchArguments.split(" ", Qt::SkipEmptyParts);
@@ -290,7 +290,7 @@ bool ctkAppLauncherPrivate::processApplicationToLaunchArgument()
     this->ApplicationToLaunchArguments =
         this->DefaultApplicationToLaunchArguments.split(" ", QString::SkipEmptyParts);
 #endif
-    }
+  }
 
   this->reportInfo(QString("ApplicationToLaunchArguments [%1]").
                    arg(this->ApplicationToLaunchArguments.join(" ")));
@@ -302,24 +302,24 @@ bool ctkAppLauncherPrivate::processApplicationToLaunchArgument()
 bool ctkAppLauncherPrivate::processExtraApplicationToLaunchArgument(const QStringList& unparsedArgs)
 {
   foreach(const QString& extraAppLongArgument, this->ExtraApplicationToLaunchList.keys())
-    {
+  {
     ctkAppLauncherPrivate::ExtraApplicationToLaunchProperty extraAppToLaunchProperty =
         this->ExtraApplicationToLaunchList[extraAppLongArgument];
     QString extraAppShortArgument = extraAppToLaunchProperty.value("shortArgument");
     bool hasShortArgument = false;
     if (!extraAppShortArgument.isEmpty())
-      {
+    {
       hasShortArgument = unparsedArgs.contains(this->Parser.shortPrefix() + extraAppShortArgument);
-      }
+    }
     if (unparsedArgs.contains(this->Parser.longPrefix() + extraAppLongArgument) || hasShortArgument)
-      {
+    {
       this->ExtraApplicationToLaunchLongArgument = extraAppLongArgument;
       this->ExtraApplicationToLaunchShortArgument = extraAppToLaunchProperty.value("shortArgument");
       this->ExtraApplicationToLaunch = extraAppToLaunchProperty.value("path");
       this->ExtraApplicationToLaunchArguments = extraAppToLaunchProperty.value("arguments");
       break;
-      }
     }
+  }
   return true;
 }
 
@@ -329,9 +329,9 @@ QString ctkAppLauncherPrivate::invalidSettingsMessage() const
   QString msg = QString("Launcher setting file [%1LauncherSettings.ini] does NOT exist in "
                         "any of these directories:\n").arg(this->LauncherName);
   foreach(const QString& subdir, this->LauncherSettingSubDirs)
-    {
+  {
     msg.append(QString("%1/%2\n").arg(this->LauncherDir).arg(subdir));
-    }
+  }
   return msg;
 }
 
@@ -345,9 +345,9 @@ bool ctkAppLauncherPrivate::verbose() const
 QString ctkAppLauncherPrivate::splashImagePath()const
 {
   if (!this->Initialized)
-    {
+  {
     return this->DefaultLauncherSplashImagePath;
-    }
+  }
 
   return this->LauncherSplashImagePath;
 }
@@ -357,24 +357,24 @@ bool ctkAppLauncherPrivate::disableSplash() const
 {
   bool hasNoSplashArgument = false;
   foreach(const QString& arg, this->LauncherAdditionalNoSplashArguments)
-    {
+  {
 
     if (this->Parser.unparsedArguments().contains(arg) ||
         this->ParsedArgs.contains(this->trimArgumentPrefix(arg))
         )
-      {
+    {
       hasNoSplashArgument = true;
       break;
-      }
     }
+  }
   if (this->ParsedArgs.value("launcher-no-splash").toBool()
       || hasNoSplashArgument
       || !this->ExtraApplicationToLaunch.isEmpty()
       || this->LauncherNoSplashScreen
       || !this->ParsedArgs.value("launch").toString().isEmpty())
-    {
+  {
     return true;
-    }
+  }
   return false;
 }
 
@@ -384,30 +384,30 @@ QString ctkAppLauncherPrivate::searchPaths(const QString& executableName, const 
   QStringList paths = this->SystemEnvironment.value(this->PathVariableName).split(this->PathSep);
   paths = this->ListOfPaths + paths;
   foreach(const QString& path, paths)
-    {
+  {
     QString expandedPath = this->expandValue(path);
     foreach(const QString& extension, extensions)
-      {
+    {
       QString executableNameWithExt = executableName;
       if (!extension.isEmpty())
-        {
+      {
         executableNameWithExt.append("." + extension);
-        }
+      }
       QDir pathAsDir(expandedPath);
       QString executablePath = pathAsDir.filePath(executableNameWithExt);
       QString msg = QString("Checking if [%1] exists in [%2]").arg(executableNameWithExt).arg(expandedPath);
       this->reportInfo(msg);
       if (QFile::exists(executablePath) && QFileInfo(executablePath).isFile() && QFileInfo(executablePath).isExecutable())
-        {
+      {
         this->reportInfo(msg + " - Found");
         return executablePath;
-        }
+      }
       else
-        {
+      {
         this->reportInfo(msg + " - Not found");
-        }
       }
     }
+  }
   return QString();
 }
 
@@ -416,13 +416,13 @@ QString ctkAppLauncherPrivate::trimArgumentPrefix(const QString& argument) const
 {
   QString trimmedArgument = argument;
   if (trimmedArgument.startsWith(this->LongArgPrefix))
-    {
+  {
     trimmedArgument.remove(0, this->LongArgPrefix.length());
-    }
+  }
   else if (trimmedArgument.startsWith(this->ShortArgPrefix))
-    {
+  {
     trimmedArgument.remove(0, this->ShortArgPrefix.length());
-    }
+  }
   return trimmedArgument;
 }
 
@@ -433,39 +433,39 @@ bool ctkAppLauncherPrivate::extractLauncherNameAndDir(const QString& application
 
   // In case a symlink to the launcher is available from the PATH, resolve its location.
   if (!fileInfo.exists())
-    {
+  {
     QStringList paths = this->SystemEnvironment.value(this->PathVariableName).split(this->PathSep);
     foreach(const QString& path, paths)
-      {
+    {
       QString executablePath = QDir(path).filePath(fileInfo.fileName());
       QString msg = QString("Checking if [%1] exists in [%2]").arg(fileInfo.fileName()).arg(path);
       this->reportInfo(msg);
       if (QFile::exists(executablePath))
-        {
+      {
         this->reportInfo(msg + " - Found");
         fileInfo = QFileInfo(executablePath);
         break;
-        }
+      }
       else
-        {
+      {
         this->reportInfo(msg + " - Not found");
-        }
       }
     }
+  }
 
   // Follow symlink if it applies
   if (fileInfo.isSymLink())
-    {
+  {
     // symLinkTarget() handles links pointing to symlinks.
     fileInfo = QFileInfo(fileInfo.symLinkTarget());
-    }
+  }
 
   // Make sure the obtained target exists and is a "file"
   if (!fileInfo.exists() && !fileInfo.isFile())
-    {
+  {
     this->reportError("Failed to obtain launcher executable name !");
     return false;
-    }
+  }
 
   // Obtain executable name
   this->LauncherName = fileInfo.baseName();
@@ -481,12 +481,12 @@ QString ctkAppLauncherPrivate::shellQuote(bool posix, QString text, const QStrin
 {
 #ifdef Q_OS_WIN32
   if (!posix)
-    {
+  {
     static QRegExp reSpecialCharacters("([\"^])");
     text.replace(reSpecialCharacters, "^\\1");
     text.replace("\n", "^\n\n");
     return text + trailing;
-    }
+  }
 #else
   Q_UNUSED(posix)
 #endif
@@ -504,46 +504,46 @@ void ctkAppLauncherPrivate::buildEnvironment(QProcessEnvironment &env)
   this->reportInfo(QString("<APPLAUNCHER_DIR> -> [%1]").arg(this->LauncherDir));
   this->reportInfo(QString("<APPLAUNCHER_NAME> -> [%1]").arg(this->LauncherName));
   foreach(const Self::SettingsType& settingsType, this->LauncherSettingsDirs.keys())
-    {
+  {
     ScopedLauncherSettingsDir scopedLauncherSettingsDir(this, settingsType);
     Q_UNUSED(scopedLauncherSettingsDir);
     this->reportInfo(
           QString("<APPLAUNCHER_SETTINGS_DIR> (%1) -> [%2]").arg(Self::settingsTypeToString(settingsType)).arg(q->launcherSettingsDir()));
-    }
+  }
   this->reportInfo(QString("<PATHSEP> -> [%1]").arg(this->PathSep));
 
   if(this->LoadEnvironment >= 0)
-    {
+  {
     env = ctkAppLauncherEnvironment::environment(this->LoadEnvironment);
-    }
+  }
 
   // Regular environment variables
   QHash<QString, QString> envVars = q->envVars();
   foreach(const QString& key, envVars.keys())
-    {
+  {
     this->reportInfo(QString("Setting env. variable [%1]:%2").arg(key, envVars[key]));
     env.insert(key, envVars[key]);
-    }
+  }
 
   // Path environment variables
   QHash<QString, QStringList> pathsEnvVars = q->pathsEnvVars();
   foreach(const QString& key, pathsEnvVars.keys())
-    {
+  {
     const QStringList& paths = pathsEnvVars[key];
     QString value = paths.join(this->PathSep);
     this->reportInfo(QString("Setting env. variable [%1]:%2").arg(key, value));
     if (env.contains(key))
-      {
+    {
       value = QString("%1%2%3").arg(value, this->PathSep, env.value(key));
-      }
-    env.insert(key, value);
     }
+    env.insert(key, value);
+  }
 
   // Do not save environment if one should be loaded
   if(this->LoadEnvironment >= 0)
-    {
+  {
     return;
-    }
+  }
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QStringList envVarNames = q->envVars().keys();
@@ -567,96 +567,96 @@ void ctkAppLauncherPrivate::buildEnvironment(QProcessEnvironment &env)
 bool ctkAppLauncherPrivate::readSettings(const QString& fileName, int settingsType)
 {
   if (!this->Initialized)
-    {
+  {
     return false;
-    }
+  }
 
   if (!this->checkSettings(fileName, settingsType))
-    {
+  {
     if (!this->ReadSettingsError.isEmpty())
-      {
+    {
       this->reportError(this->ReadSettingsError);
-      }
-    return false;
     }
+    return false;
+  }
   QSettings settings(fileName, QSettings::IniFormat);
 
   this->LoadEnvironment = settings.value("launcherLoadEnvironment", -1).toInt();
 
   if(settingsType == Self::RegularSettings)
-    {
+  {
     // Read "user additional settings" and "additional settings" info
     this->readUserAdditionalSettingsInfo(settings);
     this->readAdditionalSettingsInfo(settings);
-    }
+  }
 
   QStringList excludeGroups;
   if (settingsType != Self::RegularSettings)
-    {
+  {
     excludeGroups = this->AdditionalSettingsExcludeGroups;
-    }
+  }
 
   if (!excludeGroups.contains("General"))
-    {
+  {
     // Read default launcher image path
     QVariant splashImagePathVariant = settings.value("launcherSplashImagePath");
     if (splashImagePathVariant.isValid() && !splashImagePathVariant.toString().isEmpty())
-      {
+    {
       this->DefaultLauncherSplashImagePath = splashImagePathVariant.toString();
-      }
+    }
 
     QVariant splashScreenHideDelayMsVariant = settings.value("launcherSplashScreenHideDelayMs");
     if (splashScreenHideDelayMsVariant.isValid() && splashScreenHideDelayMsVariant.toInt() != 0)
-      {
+    {
       this->DefaultLauncherSplashScreenHideDelayMs = splashScreenHideDelayMsVariant.toInt();
-      }
+    }
 
     if (settings.contains("launcherNoSplashScreen"))
-      {
+    {
       this->LauncherNoSplashScreen = settings.value("launcherNoSplashScreen").toBool();
-      }
+    }
 
     // Read additional launcher arguments
     QString helpShortArgument = settings.value("additionalLauncherHelpShortArgument").toString();
     if (!helpShortArgument.isEmpty())
-      {
+    {
       this->LauncherAdditionalHelpShortArgument = helpShortArgument;
-      }
+    }
     QString helpLongArgument = settings.value("additionalLauncherHelpLongArgument").toString();
     if (!helpLongArgument.isEmpty())
-      {
+    {
       this->LauncherAdditionalHelpLongArgument = helpLongArgument;
-      }
+    }
     this->LauncherAdditionalNoSplashArguments.append(
           settings.value("additionalLauncherNoSplashArguments").toStringList());
-    }
+  }
 
   if (!excludeGroups.contains("Application"))
-    {
+  {
     // Read default application to launch
     QHash<QString, QString> applicationGroup = ctk::readKeyValuePairs(settings, "Application");
     if (applicationGroup.contains("path"))
-      {
+    {
       this->DefaultApplicationToLaunch = applicationGroup["path"];
-      }
-    if (applicationGroup.contains("arguments"))
-      {
-      this->DefaultApplicationToLaunchArguments = applicationGroup["arguments"];
-      }
     }
+    if (applicationGroup.contains("arguments"))
+    {
+      this->DefaultApplicationToLaunchArguments = applicationGroup["arguments"];
+    }
+  }
 
   if (!excludeGroups.contains("ExtraApplicationToLaunch"))
-    {
+  {
     // Read list of 'extra application to launch'
     settings.beginGroup("ExtraApplicationToLaunch");
     QStringList extraApplicationToLaunchLongArguments = settings.childGroups();
     foreach(const QString& extraApplicationLongArgument, extraApplicationToLaunchLongArguments)
-      {
+    {
       this->ExtraApplicationToLaunchList[extraApplicationLongArgument] =
           ctk::readKeyValuePairs(settings, extraApplicationLongArgument);
-      }
-    settings.endGroup();
     }
+    settings.endGroup();
+  }
 
   this->Superclass::readPathSettings(settings, excludeGroups);
 
@@ -680,33 +680,33 @@ void ctkAppLauncherPrivate::runProcess()
 
   this->reportInfo(QString("Starting [%1]").arg(this->ApplicationToLaunch));
   if (this->verbose())
-    {
+  {
     foreach(const QString& argument, this->ApplicationToLaunchArguments)
-      {
+    {
       this->reportInfo(QString("argument [%1]").arg(argument));
-      }
     }
+  }
 
   connect(&this->Process, SIGNAL(finished(int, QProcess::ExitStatus)),
           this, SLOT(applicationFinished(int, QProcess::ExitStatus)));
   connect(&this->Process, SIGNAL(started()), this, SLOT(applicationStarted()));
 
   if (!this->DetachApplicationToLaunch)
-    {
+  {
     this->Process.start(this->ApplicationToLaunch, this->ApplicationToLaunchArguments);
     int timeoutInMs = this->ParsedArgs.value("launcher-timeout").toInt() * 1000;
     this->reportInfo(QString("launcher-timeout (ms) [%1]").arg(timeoutInMs));
     if (timeoutInMs > 0)
-      {
-      QTimer::singleShot(timeoutInMs, this, SLOT(terminateProcess()));
-      }
-    }
-  else
     {
+      QTimer::singleShot(timeoutInMs, this, SLOT(terminateProcess()));
+    }
+  }
+  else
+  {
     this->Process.startDetached(
       this->ApplicationToLaunch, this->ApplicationToLaunchArguments);
     this->exit(EXIT_SUCCESS);
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -719,16 +719,16 @@ void ctkAppLauncherPrivate::terminateProcess()
 void ctkAppLauncherPrivate::applicationFinished(int exitCode, QProcess::ExitStatus  exitStatus)
 {
   if (exitStatus == QProcess::NormalExit)
-    {
+  {
     this->exit(exitCode);
-    }
+  }
   else if (exitStatus == QProcess::CrashExit)
-    {
+  {
     this->reportError(
       QString("[%1] exit abnormally - Report the problem.").
         arg(this->ApplicationToLaunch));
     this->exit(EXIT_FAILURE);
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -737,7 +737,7 @@ void ctkAppLauncherPrivate::applicationStarted()
   this->reportInfo(
     QString("DisableSplash [%1]").arg(this->disableSplash()));
   if(!this->disableSplash())
-    {
+  {
     this->SplashPixmap.reset(
       new QPixmap(this->splashImagePath()));
     this->SplashScreen = QSharedPointer<QSplashScreen>(
@@ -745,7 +745,7 @@ void ctkAppLauncherPrivate::applicationStarted()
     this->SplashScreen->show();
     QTimer::singleShot(this->LauncherSplashScreenHideDelayMs,
                        this->SplashScreen.data(), SLOT(hide()));
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -774,21 +774,21 @@ void ctkAppLauncher::displayEnvironment(std::ostream &output)
 {
   Q_D(ctkAppLauncher);
   if (d->LauncherName.isEmpty())
-    {
+  {
     return;
-    }
+  }
   QProcessEnvironment env;
   d->buildEnvironment(env);
   QStringList envAsList = env.toStringList();
   envAsList.sort();
   foreach (const QString& envArg, envAsList)
-    {
+  {
     output << qPrintable(envArg) << std::endl;
-    }
+  }
   if(envAsList.isEmpty())
-    {
+  {
     output << "(No environment to display)" << std::endl;
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -796,9 +796,9 @@ void ctkAppLauncher::generateEnvironmentScript(QTextStream &output, bool posix)
 {
   Q_D(ctkAppLauncher);
   if (d->LauncherName.isEmpty())
-    {
+  {
     return;
-    }
+  }
 
   QProcessEnvironment env;
 
@@ -822,18 +822,18 @@ void ctkAppLauncher::generateEnvironmentScript(QTextStream &output, bool posix)
 #endif
 
   foreach(const QString& key, envKeys)
-    {
+  {
     const QString pair = QString("%1=%2").arg(key, env.value(key));
     if (appendVars.contains(key))
-      {
+    {
       const QString trailing = appendFormat.arg(key, d->PathSep);
       output << exportFormat.arg(d->shellQuote(posix, pair, trailing)) << '\n';
-      }
-    else
-      {
-      output << exportFormat.arg(d->shellQuote(posix, pair)) << '\n';
-      }
     }
+    else
+    {
+      output << exportFormat.arg(d->shellQuote(posix, pair)) << '\n';
+    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -841,9 +841,9 @@ bool ctkAppLauncher::generateExecWrapperScript()
 {
   Q_D(ctkAppLauncher);
   if (d->LauncherName.isEmpty())
-    {
+  {
     return false;
-    }
+  }
 
 #ifdef Q_OS_WIN32
   const QString scriptComment("::");
@@ -856,10 +856,10 @@ bool ctkAppLauncher::generateExecWrapperScript()
   QTemporaryFile launcherScript(QDir::temp().filePath("Slicer-XXXXXX.%1").arg(scriptExtension));
   launcherScript.setAutoRemove(false);
   if (!launcherScript.open())
-    {
+  {
     d->reportError("Failed to generate executable wrapper script.");
     return false;
-    }
+  }
   QTextStream out(&launcherScript);
 
 #ifndef Q_OS_WIN32
@@ -891,19 +891,19 @@ void ctkAppLauncher::displayHelp(std::ostream &output)
 {
   Q_D(ctkAppLauncher);
   if (d->LauncherName.isEmpty())
-    {
+  {
     return;
-    }
+  }
 
   // Add "extra application to launch" arguments so that helpText() consider them.
   foreach(const QString& extraAppLongArgument, d->ExtraApplicationToLaunchList.keys())
-    {
+  {
     ctkAppLauncherPrivate::ExtraApplicationToLaunchProperty extraAppToLaunchProperty =
         d->ExtraApplicationToLaunchList[extraAppLongArgument];
     QString extraAppShortArgument = extraAppToLaunchProperty.value("shortArgument");
     d->Parser.addArgument(extraAppLongArgument, extraAppShortArgument, QVariant::Bool,
                                        extraAppToLaunchProperty.value("help"));
-    }
+  }
 
   output << "Usage\n";
   output << "  " << qPrintable(d->LauncherName) << " [options]\n\n";
@@ -916,9 +916,9 @@ void ctkAppLauncher::displayVersion(std::ostream &output)
 {
   Q_D(ctkAppLauncher);
   if (d->LauncherName.isEmpty())
-    {
+  {
     return;
-    }
+  }
   output << qPrintable(d->LauncherName) << " launcher version " CTKAppLauncher_VERSION << "\n";
 }
 
@@ -927,9 +927,9 @@ bool ctkAppLauncher::initialize(QString launcherFilePath)
 {
   Q_D(ctkAppLauncher);
   if (d->Initialized)
-    {
+  {
     return true;
-    }
+  }
 
   // Set verbose flags now so that call to "reportInfo" in "initialize" method properly
   // display information.
@@ -937,13 +937,13 @@ bool ctkAppLauncher::initialize(QString launcherFilePath)
         "launcher-verbose", QVariant(d->Arguments.contains("--launcher-verbose")));
 
   if (launcherFilePath.isEmpty() && d->Application)
-    {
+  {
     launcherFilePath = d->Application->applicationFilePath();
-    }
+  }
   if (!d->extractLauncherNameAndDir(launcherFilePath))
-    {
+  {
     return false;
-    }
+  }
 
   ctkCommandLineParser & parser = d->Parser;
   parser.setArgumentPrefix(d->LongArgPrefix, d->ShortArgPrefix);
@@ -994,9 +994,9 @@ void ctkAppLauncher::setApplication(const QCoreApplication& app)
   Q_D(ctkAppLauncher);
   d->Application = app.instance();
   if (d->Application && d->Arguments.empty())
-    {
+  {
     this->setArguments(d->Application->arguments());
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -1018,19 +1018,19 @@ int ctkAppLauncher::processArguments()
 {
   Q_D(ctkAppLauncher);
   if (!d->Initialized)
-    {
+  {
     return Self::ExitWithError;
-    }
+  }
 
   bool ok = false;
   d->ParsedArgs =
       d->Parser.parseArguments(d->Arguments, &ok);
   if (!ok)
-    {
+  {
     std::cerr << "Error\n  "
               << qPrintable(d->Parser.errorString()) << "\n" << std::endl;
     return Self::ExitWithError;
-    }
+  }
 
   bool reportInfo = d->LauncherStarting
       || d->ParsedArgs.value("launcher-help").toBool()
@@ -1041,44 +1041,44 @@ int ctkAppLauncher::processArguments()
       || d->ParsedArgs.value("launcher-generate-exec-wrapper-script").toBool();
 
   if (d->ParsedArgs.value("launcher-help").toBool())
-    {
+  {
     this->displayHelp();
     return Self::ExitWithSuccess;
-    }
+  }
 
   if (d->ParsedArgs.value("launcher-version").toBool())
-    {
+  {
     this->displayVersion();
     return Self::ExitWithSuccess;
-    }
+  }
 
   // Read additional settings group to exclude
   if (d->ParsedArgs.contains("launcher-additional-settings-exclude-groups"))
-    {
+  {
     d->AdditionalSettingsExcludeGroups = d->ParsedArgs.value("launcher-additional-settings-exclude-groups").toString().split(",");
-    }
+  }
 
   // Regular settings are parsed before calling this function in ctkAppLauncher::configure()
 
   if (!d->processUserAdditionalSettings())
-    {
+  {
     return Self::ExitWithError;
-    }
+  }
 
   if (!d->processAdditionalSettings())
-    {
+  {
     return Self::ExitWithError;
-    }
+  }
 
   if (!d->processAdditionalSettingsArgument())
-    {
+  {
     return Self::ExitWithError;
-    }
+  }
 
   d->reportInfo(QString("AdditionalSettingsFilePath [%1]").arg(d->AdditionalSettingsFilePath));
 
   if (reportInfo)
-    {
+  {
     d->reportInfo(
         QString("LauncherDir [%1]").arg(d->LauncherDir));
 
@@ -1129,82 +1129,82 @@ int ctkAppLauncher::processArguments()
 
     d->reportInfo(
         QString("AdditionalLauncherNoSplashArguments [%1]").arg(d->LauncherAdditionalNoSplashArguments.join(",")));
-    }
+  }
 
   d->DetachApplicationToLaunch =
       d->ParsedArgs.value("launcher-detach").toBool();
   if (d->LauncherStarting)
-    {
+  {
     d->reportInfo(
         QString("DetachApplicationToLaunch [%1]").arg(d->DetachApplicationToLaunch));
-    }
+  }
 
   if (d->ParsedArgs.contains("launcher-load-environment"))
-    {
+  {
     d->LoadEnvironment =
         d->ParsedArgs.value("launcher-load-environment").toInt();
-    }
+  }
   if (reportInfo)
-    {
+  {
     d->reportInfo(
         QString("LoadEnvironment [%1]").arg(d->LoadEnvironment));
-    }
+  }
 
   QStringList unparsedArgs = d->Parser.unparsedArguments();
 
   if (!d->processExtraApplicationToLaunchArgument(unparsedArgs))
-    {
+  {
     return Self::ExitWithError;
-    }
+  }
 
   if (unparsedArgs.contains(d->LauncherAdditionalHelpShortArgument) ||
       unparsedArgs.contains(d->LauncherAdditionalHelpLongArgument))
-    {
+  {
     if (d->LauncherStarting && d->ExtraApplicationToLaunch.isEmpty())
-      {
+    {
       this->displayHelp();
-      }
     }
+  }
 
   if (d->ParsedArgs.value("launcher-generate-template").toBool())
-    {
+  {
     bool success = this->generateTemplate();
     return success ? Self::ExitWithSuccess : Self::ExitWithError;
-    }
+  }
 
   if (!d->processSplashPathArgument())
-    {
+  {
     return Self::ExitWithError;
-    }
+  }
 
   if (!d->processScreenHideDelayMsArgument())
-    {
+  {
     return Self::ExitWithError;
-    }
+  }
 
   if (d->ParsedArgs.value("launcher-show-set-environment-commands").toBool())
-    {
+  {
     QTextStream out(stdout);
     this->generateEnvironmentScript(out, true);
     return Self::ExitWithSuccess;
-    }
+  }
 
   if (d->ParsedArgs.value("launcher-generate-exec-wrapper-script").toBool())
-    {
+  {
     bool success = this->generateExecWrapperScript();
     return success ? Self::ExitWithSuccess : Self::ExitWithError;
-    }
+  }
 
   if (d->ParsedArgs.value("launcher-dump-environment").toBool())
-    {
+  {
     this->displayEnvironment();
     return Self::ExitWithSuccess;
-    }
+  }
 
   if (!d->processApplicationToLaunchArgument())
-    {
+  {
     return Self::ExitWithError;
-    }
+  }
 
   return Self::Continue;
 }
@@ -1214,20 +1214,20 @@ QString ctkAppLauncher::findSettingsFile()const
 {
   Q_D(const ctkAppLauncher);
   if (!d->Initialized)
-    {
+  {
     return QString();
-    }
+  }
 
   foreach(const QString& subdir, d->LauncherSettingSubDirs)
-    {
+  {
     QString fileName = QString("%1/%2/%3LauncherSettings.ini").
                        arg(d->LauncherDir).arg(subdir).
                        arg(d->LauncherName);
     if (QFile::exists(fileName))
-      {
+    {
       return fileName;
-      }
     }
+  }
   return QString();
 }
 
@@ -1235,18 +1235,18 @@ bool ctkAppLauncher::writeSettings(const QString& outputFilePath)
 {
   Q_D(ctkAppLauncher);
   if (!d->Initialized)
-    {
+  {
     return false;
-    }
+  }
 
   // Create or open settings file ...
   QSettings settings(outputFilePath, QSettings::IniFormat);
   if (settings.status() != QSettings::NoError)
-    {
+  {
     d->reportError(
       QString("Failed to open setting file [%1]").arg(outputFilePath));
     return false;
-    }
+  }
 
   // Clear settings
   settings.clear();
@@ -1265,11 +1265,11 @@ bool ctkAppLauncher::writeSettings(const QString& outputFilePath)
 
   settings.beginGroup("ExtraApplicationToLaunch");
   foreach(const QString& extraAppLongArgument, d->ExtraApplicationToLaunchList.keys())
-    {
+  {
     ctkAppLauncherPrivate::ExtraApplicationToLaunchProperty extraAppToLaunchProperty =
         d->ExtraApplicationToLaunchList.value(extraAppLongArgument);
     ctk::writeKeyValuePairs(settings, extraAppToLaunchProperty, extraAppLongArgument);
-    }
+  }
   settings.endGroup();
 
   ctk::writeArrayValues(settings, d->ListOfPaths, "Paths", "path");
@@ -1298,9 +1298,9 @@ int ctkAppLauncher::splashScreenHideDelayMs()const
 {
   Q_D(const ctkAppLauncher);
   if (!d->Initialized)
-    {
+  {
     return d->DefaultLauncherSplashScreenHideDelayMs;
-    }
+  }
 
   return d->LauncherSplashScreenHideDelayMs;
 }
@@ -1324,9 +1324,9 @@ void ctkAppLauncher::startApplication()
 {
   Q_D(ctkAppLauncher);
   if (!d->Initialized)
-    {
+  {
     return;
-    }
+  }
   QTimer::singleShot(0, d, SLOT(runProcess()));
 }
 
@@ -1376,65 +1376,65 @@ int ctkAppLauncher::configure()
 {
   Q_D(ctkAppLauncher);
   if (!this->initialize())
-    {
+  {
     d->exit(EXIT_FAILURE);
     return ctkAppLauncher::ExitWithError;
-    }
+  }
 
   QString settingFileName = this->findSettingsFile();
   if (!settingFileName.isEmpty())
-    {
+  {
     d->LauncherSettingsDirs[ctkAppLauncherPrivate::RegularSettings] = QFileInfo(settingFileName).absoluteDir().absolutePath();
-    }
+  }
 
   d->ValidSettingsFile = d->readSettings(settingFileName, ctkAppLauncherPrivate::RegularSettings);
 
   if (d->ValidSettingsFile)
-    {
+  {
     if (!d->OrganizationName.isEmpty())
-      {
+    {
       qApp->setOrganizationName(d->OrganizationName);
-      }
-    if (!d->OrganizationDomain.isEmpty())
-      {
-      qApp->setOrganizationDomain(d->OrganizationDomain);
-      }
-    if (!d->ApplicationName.isEmpty())
-      {
-      qApp->setApplicationName(d->ApplicationName);
-      }
     }
+    if (!d->OrganizationDomain.isEmpty())
+    {
+      qApp->setOrganizationDomain(d->OrganizationDomain);
+    }
+    if (!d->ApplicationName.isEmpty())
+    {
+      qApp->setApplicationName(d->ApplicationName);
+    }
+  }
 
   // Process command line arguments and load additional settings files if any
   int status = this->processArguments();
   if (status == ctkAppLauncher::ExitWithError)
-    {
+  {
     if (!d->ValidSettingsFile)
-      {
+    {
       d->reportError(d->invalidSettingsMessage());
-      }
+    }
     this->displayHelp(std::cerr);
     d->exit(EXIT_FAILURE);
     return status;
-    }
+  }
   else if (status == ctkAppLauncher::ExitWithSuccess)
-    {
+  {
     d->exit(EXIT_SUCCESS);
     return status;
-    }
+  }
 
   // Append 'unparsed arguments' to list of arguments that will be used to start the application.
   // If it applies, extra 'application to launch' short and long arguments should be
   // removed from that list.
   QStringList unparsedArguments = d->Parser.unparsedArguments();
   if (!d->ExtraApplicationToLaunchShortArgument.isEmpty())
-    {
+  {
     unparsedArguments.removeAll(d->Parser.shortPrefix() + d->ExtraApplicationToLaunchShortArgument);
-    }
+  }
   if (!d->ExtraApplicationToLaunchLongArgument.isEmpty())
-    {
+  {
     unparsedArguments.removeAll(d->Parser.longPrefix() + d->ExtraApplicationToLaunchLongArgument);
-    }
+  }
 
   d->ApplicationToLaunchArguments.append(unparsedArguments);
   return status;
@@ -1447,8 +1447,8 @@ void ctkAppLauncher::startLauncher()
   d->LauncherStarting = true;
   int res = this->configure();
   if (res != Self::Continue)
-    {
+  {
     return;
-    }
+  }
   this->startApplication();
 }

--- a/Base/ctkAppLauncher.h
+++ b/Base/ctkAppLauncher.h
@@ -123,11 +123,11 @@ public:
   ~ctkAppLauncher();
 
   enum ProcessArgumentsStatus
-    {
+  {
     ExitWithError = 0,
     ExitWithSuccess,
     Continue
-    };
+  };
 
   /// Display environment variables on standard output
   void displayEnvironment(std::ostream &output = std::cout);

--- a/Base/ctkAppLauncherEnvironment.cpp
+++ b/Base/ctkAppLauncherEnvironment.cpp
@@ -51,9 +51,9 @@ int ctkAppLauncherEnvironment::currentLevel()
 {
   const char* levelStr = getenv("APPLAUNCHER_LEVEL");
   if (!levelStr)
-    {
+  {
     return 0;
-    }
+  }
   int level = QString("%1").arg(levelStr).toInt();
   return level >= 0 ? level : 0;
 }
@@ -63,42 +63,42 @@ QProcessEnvironment ctkAppLauncherEnvironment::environment(int requestedLevel)
 {
   QProcessEnvironment currentEnv = QProcessEnvironment::systemEnvironment();
   if (requestedLevel == Self::currentLevel())
-    {
+  {
     return currentEnv;
-    }
+  }
   else if (requestedLevel > Self::currentLevel() || requestedLevel < 0)
-    {
+  {
     return QProcessEnvironment();
-    }
+  }
   QProcessEnvironment env(currentEnv);
   QStringList currentEnvKeys = Self::envKeys(currentEnv);
   QStringList requestedEnvKeys;
   foreach(const QString& varname, currentEnvKeys)
-    {
+  {
     if (ctkAppLauncherEnvironmentPrivate::LevelVarNameRegex.indexIn(varname) == 0)
-      {
+    {
       int currentLevel = ctkAppLauncherEnvironmentPrivate::LevelVarNameRegex.cap(1).toInt();
       if (currentLevel == requestedLevel)
-        {
+      {
         QString currentVarName = QString(varname).remove(0, ctkAppLauncherEnvironmentPrivate::LevelVarNameRegex.matchedLength());
         env.insert(currentVarName, currentEnv.value(varname));
         env.remove(varname);
         requestedEnvKeys.append(currentVarName);
-        }
+      }
       else if (currentLevel > requestedLevel)
-        {
+      {
         env.remove(varname);
-        }
       }
     }
+  }
   if (requestedLevel == 0)
-    {
+  {
     env.remove("APPLAUNCHER_LEVEL");
-    }
+  }
   else if (requestedLevel > 0)
-    {
+  {
     env.insert("APPLAUNCHER_LEVEL", QString("%1").arg(requestedLevel));
-    }
+  }
 
   // Remove variables that are present in current environment but not
   // associated with the requested saved level.
@@ -114,9 +114,9 @@ QProcessEnvironment ctkAppLauncherEnvironment::environment(int requestedLevel)
       - ctkAppLauncherEnvironment::excludeReservedVariableNames(requestedEnvKeys).toSet();
 #endif
   foreach(const QString& varname, variablesToRemove.values())
-    {
+  {
     env.remove(varname);
-    }
+  }
 
   return env;
 }
@@ -129,24 +129,24 @@ void ctkAppLauncherEnvironment::saveEnvironment(
   // Keep track of launcher level
   int launcher_level = 1;
   if (systemEnvironment.contains("APPLAUNCHER_LEVEL"))
-    {
+  {
     launcher_level =
         systemEnvironment.value("APPLAUNCHER_LEVEL").toInt() + 1;
-    }
+  }
   env.insert("APPLAUNCHER_LEVEL", QString("%1").arg(launcher_level));
 
   // Save value environment variables
   foreach(const QString& varname, variables)
-    {
+  {
     if (!systemEnvironment.contains(varname)
         || ctkAppLauncherEnvironment::isReservedVariableName(varname))
-      {
+    {
       continue;
-      }
+    }
     QString saved_varname = QString("APPLAUNCHER_%1_%2").arg(launcher_level - 1).arg(varname);
     QString saved_value = systemEnvironment.value(varname, "");
     env.insert(saved_varname, saved_value);
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -164,29 +164,29 @@ void ctkAppLauncherEnvironment::updateCurrentEnvironment(const QProcessEnvironme
   QStringList variablesToUnset = (curKeys.toSet() - envKeys.toSet()).toList();
 #endif
   foreach(const QString& varName, variablesToUnset)
-    {
+  {
 #if defined(Q_OS_WIN32)
     bool success = qputenv(varName.toLocal8Bit(), QString().toLocal8Bit());
 #else
     bool success = unsetenv(varName.toLocal8Bit()) == EXIT_SUCCESS;
 #endif
     if (!success)
-      {
+    {
       qWarning() << "Failed to unset environment variable" << varName;
-      }
     }
+  }
 
   // Set variables
   foreach(const QString& varName, envKeys)
-    {
+  {
     QString varValue = environment.value(varName);
     bool success = qputenv(varName.toLocal8Bit(), varValue.toLocal8Bit());
     if (!success)
-      {
+    {
       qWarning() << "Failed to set environment variable"
                  << varName << "=" << varValue;
-      }
     }
+  }
 }
 
 // ----------------------------------------------------------------------------
@@ -197,9 +197,9 @@ QStringList ctkAppLauncherEnvironment::envKeys(const QProcessEnvironment& env)
 #else
   QStringList envKeys;
   foreach (const QString& pair, env.toStringList())
-    {
+  {
     envKeys.append(pair.split("=").first());
-    }
+  }
   return envKeys;
 #endif
 }
@@ -218,13 +218,13 @@ QString ctkAppLauncherEnvironment::casedVariableName(const QStringList& names, c
   QRegExp rx(variableName, Qt::CaseInsensitive);
   int index = names.indexOf(rx);
   if (index >= 0)
-    {
+  {
     return names.value(index);
-    }
+  }
   else
-    {
+  {
     return variableName;
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -232,12 +232,12 @@ QStringList ctkAppLauncherEnvironment::excludeReservedVariableNames(const QStrin
 {
   QStringList updatedList;
   foreach(const QString& varname, variableNames)
-    {
+  {
     if (ctkAppLauncherEnvironment::isReservedVariableName(varname))
-      {
+    {
       continue;
-      }
-    updatedList.append(varname);
     }
+    updatedList.append(varname);
+  }
   return updatedList;
 }

--- a/Base/ctkAppLauncherSettings.cpp
+++ b/Base/ctkAppLauncherSettings.cpp
@@ -64,9 +64,9 @@ QString ctkAppLauncherSettingsPrivate::findUserAdditionalSettings()const
   QString prefix = QFileInfo(QSettings().fileName()).completeBaseName();
   QString suffix;
   if (!this->ApplicationRevision.isEmpty())
-    {
+  {
     suffix = "-" + this->ApplicationRevision;
-    }
+  }
 
   QStringList candidateUserAdditionalSettingsDirs;
 
@@ -78,16 +78,16 @@ QString ctkAppLauncherSettingsPrivate::findUserAdditionalSettings()const
   candidateUserAdditionalSettingsDirs << fileInfo.path();
 
   foreach(QString candidateUserAdditionalSettingsDir, candidateUserAdditionalSettingsDirs)
-    {
+  {
     QString fileName = QDir(candidateUserAdditionalSettingsDir).filePath(QString("%1%2%3.ini").
         arg(prefix).
         arg(this->UserAdditionalSettingsFileBaseName).
         arg(suffix));
     if (QFile::exists(fileName))
-      {
+    {
       return fileName;
-      }
     }
+  }
 
   return QString();
 }
@@ -96,34 +96,34 @@ QString ctkAppLauncherSettingsPrivate::findUserAdditionalSettings()const
 QString ctkAppLauncherSettingsPrivate::settingsTypeToString(const SettingsType& settingsType)
 {
   if (settingsType == Self::RegularSettings)
-    {
+  {
     return QLatin1String("RegularSettings");
-    }
+  }
   else if (settingsType == Self::UserAdditionalSettings)
-    {
+  {
     return QLatin1String("UserAdditionalSettings");
-    }
+  }
   else // if (settingsType == Self::AdditionalSettings)
-    {
+  {
     return QLatin1String("AdditionalSettings");
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
 QString ctkAppLauncherSettingsPrivate::settingsDirPlaceHolder(const SettingsType& settingsType)
 {
   if (settingsType == Self::RegularSettings)
-    {
+  {
     return QLatin1String("<APPLAUNCHER_REGULAR_SETTINGS_DIR>");
-    }
+  }
   else if (settingsType == Self::UserAdditionalSettings)
-    {
+  {
     return QLatin1String("<APPLAUNCHER_USER_ADDITIONAL_SETTINGS_DIR>");
-    }
+  }
   else // if (settingsType == Self::AdditionalSettings)
-    {
+  {
     return QLatin1String("<APPLAUNCHER_ADDITIONAL_SETTINGS_DIR>");
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -140,9 +140,9 @@ QStringList ctkAppLauncherSettingsPrivate::updateSettingDirPlaceHolder(
 {
   QStringList updatedValues;
   foreach(const QString& value, values)
-    {
+  {
     updatedValues.append(Self::updateSettingDirPlaceHolder(value, settingsType));
-    }
+  }
   return updatedValues;
 }
 
@@ -151,37 +151,37 @@ bool ctkAppLauncherSettingsPrivate::checkSettings(const QString& fileName, int s
 {
   QString settingsTypeDesc;
   if(settingsType == Self::AdditionalSettings)
-    {
+  {
     settingsTypeDesc = QLatin1String(" additional");
-    }
+  }
   if(settingsType == Self::UserAdditionalSettings)
-    {
+  {
     settingsTypeDesc = QLatin1String(" user additional");
-    }
+  }
 
   this->ReadSettingsError = QString();
 
   // Check if settings file exists
   if (fileName.isEmpty() || !QFile::exists(fileName))
-    {
+  {
     return false;
-    }
+  }
 
   if (! (QFile::permissions(fileName) & QFile::ReadOwner) )
-    {
+  {
     this->ReadSettingsError =
         QString("Failed to read%1 launcher setting file [%2]").arg(settingsTypeDesc).arg(fileName);
     return false;
-    }
+  }
 
   // Open settings file ...
   QSettings settings(fileName, QSettings::IniFormat);
   if (settings.status() != QSettings::NoError)
-    {
+  {
     this->ReadSettingsError =
         QString("Failed to open%1 setting file [%2]").arg(settingsTypeDesc).arg(fileName);
     return false;
-    }
+  }
   return true;
 }
 
@@ -205,13 +205,13 @@ void ctkAppLauncherSettingsPrivate::readAdditionalSettingsInfo(QSettings& settin
 {
   Q_Q(ctkAppLauncherSettings);
   if (settings.contains("additionalSettingsFilePath"))
-    {
+  {
     q->setAdditionalSettingsFilePath(this->expandValue(settings.value("additionalSettingsFilePath", "").toString()));
-    }
+  }
   if (settings.contains("additionalSettingsExcludeGroups"))
-    {
+  {
     this->AdditionalSettingsExcludeGroups = settings.value("additionalSettingsExcludeGroups").toStringList();
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -220,38 +220,38 @@ void ctkAppLauncherSettingsPrivate::readPathSettings(QSettings& settings, const 
   // Read additional environment variables
   QHash<QString, QString> mapOfEnvVars;
   if (!excludeGroups.contains("EnvironmentVariables"))
-    {
+  {
     mapOfEnvVars = ctk::readKeyValuePairs(settings, "EnvironmentVariables");
     foreach(const QString& envVarName, mapOfEnvVars.keys())
-      {
+    {
       this->MapOfEnvVars.insert(envVarName, mapOfEnvVars[envVarName]);
-      }
+    }
 
     this->expandEnvVars(mapOfEnvVars.keys());
-    }
+  }
 
   // Read PATHs
   if (!excludeGroups.contains("Paths"))
-    {
+  {
     this->ListOfPaths = Self::updateSettingDirPlaceHolder(
           ctk::readArrayValues(settings, "Paths", "path"), this->LauncherSettingsDirType) + this->ListOfPaths;
-    }
+  }
 
   // Read LibraryPaths
   if (!excludeGroups.contains("LibraryPaths"))
-    {
+  {
     this->ListOfLibraryPaths = Self::updateSettingDirPlaceHolder(
           ctk::readArrayValues(settings, "LibraryPaths", "path"), this->LauncherSettingsDirType) + this->ListOfLibraryPaths;
-    }
+  }
 
   // Read additional path environment variables
   if (!excludeGroups.contains("Environment") // additionalPathVariables key is associated with the "Environment" group
       ||
       !excludeGroups.contains("General") // XXX Deprecated: additionalPathVariables key used to be associated with the "General" group
       )
-    {
+  {
     if (!excludeGroups.contains("General"))
-      {
+    {
       #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
       QStringList additionalPathVariablesList = settings.value("additionalPathVariables").toStringList();
       QSet<QString> additionalPathVariablesSet = QSet<QString> (additionalPathVariablesList.begin(), additionalPathVariablesList.end());
@@ -259,9 +259,9 @@ void ctkAppLauncherSettingsPrivate::readPathSettings(QSettings& settings, const 
       QSet<QString> additionalPathVariablesSet = settings.value("additionalPathVariables").toStringList().toSet();
       #endif
       this->AdditionalPathVariables.unite(additionalPathVariablesSet); // XXX Deprecated
-      }
+    }
     if (!excludeGroups.contains("Environment"))
-      {
+    {
       settings.beginGroup("Environment");
       #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
       QStringList additionalPathVariablesList = settings.value("additionalPathVariables").toStringList();
@@ -271,25 +271,25 @@ void ctkAppLauncherSettingsPrivate::readPathSettings(QSettings& settings, const 
       #endif
       this->AdditionalPathVariables.unite(additionalPathVariablesSet);
       settings.endGroup();
-      }
+    }
 
     foreach(const QString& envVarName, this->AdditionalPathVariables)
-      {
+    {
       if (!envVarName.isEmpty())
-        {
+      {
         QStringList paths = Self::updateSettingDirPlaceHolder(
               ctk::readArrayValues(settings, envVarName, "path"), this->LauncherSettingsDirType);
         if (!paths.empty())
-          {
+        {
           if (this->MapOfPathVars.contains(envVarName))
-            {
+          {
             paths.append(this->MapOfPathVars[envVarName]);
-            }
-          this->MapOfPathVars.insert(envVarName, paths);
           }
+          this->MapOfPathVars.insert(envVarName, paths);
         }
       }
     }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -297,13 +297,13 @@ QString ctkAppLauncherSettingsPrivate::resolvePath(const QString& path) const
 {
   QFileInfo fileInfo(path);
   if (!this->LauncherDir.isEmpty() && fileInfo.isRelative())
-    {
+  {
     return QDir(this->LauncherDir).filePath(path);
-    }
+  }
   else
-    {
+  {
     return path;
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -317,21 +317,21 @@ QString ctkAppLauncherSettingsPrivate::expandValue(const QString& value) const
   QRegExp regex("\\<env\\:([a-zA-Z0-9\\-\\_]+)\\>");
   int pos = 0;
   while ((pos = regex.indexIn(value, pos)) != -1)
-    {
+  {
     pos += regex.matchedLength();
     Q_ASSERT(regex.captureCount() == 1);
     QString envVarName = regex.cap(1);
     QString envVarValue = QString("<env-NOTFOUND:%1>").arg(envVarName);
     if (mapOfEnvVars.contains(envVarName))
-      {
+    {
       envVarValue = mapOfEnvVars.value(envVarName);
-      }
-    else if (this->SystemEnvironment.contains(envVarName))
-      {
-      envVarValue = this->SystemEnvironment.value(envVarName);
-      }
-    updatedValue.replace(QString("<env:%1>").arg(envVarName), envVarValue, Qt::CaseInsensitive);
     }
+    else if (this->SystemEnvironment.contains(envVarName))
+    {
+      envVarValue = this->SystemEnvironment.value(envVarName);
+    }
+    updatedValue.replace(QString("<env:%1>").arg(envVarName), envVarValue, Qt::CaseInsensitive);
+  }
   return updatedValue;
 }
 
@@ -350,9 +350,9 @@ QString ctkAppLauncherSettingsPrivate::expandPlaceHolders(const QString& value) 
 
   QString updatedValue = value;
   foreach(const QString& key, keyValueMap.keys())
-    {
+  {
     updatedValue.replace(key, keyValueMap.value(key), Qt::CaseInsensitive);
-    }
+  }
   return updatedValue;
 }
 
@@ -364,46 +364,46 @@ void ctkAppLauncherSettingsPrivate::expandEnvVars(const QStringList& envVarNames
   QHash<QString, QString> expanded = this->MapOfEnvVars;
 
   foreach(const QString& key, this->MapOfEnvVars.keys())
-    {
+  {
     QString value = this->MapOfEnvVars[key];
     int pos = 0;
     int previousPos = pos;
     while ((pos = regex.indexIn(value, pos)) != -1)
-      {
+    {
       pos += regex.matchedLength();
       Q_ASSERT(regex.captureCount() == 1);
       QString envVarName = regex.cap(1);
       QString envVarValue = QString("<env:%1>").arg(envVarName);
       if (this->MapOfExpandedEnvVars.contains(envVarName))
-        {
+      {
         envVarValue = this->MapOfExpandedEnvVars[envVarName];
         value.replace(QString("<env:%1>").arg(envVarName), envVarValue, Qt::CaseInsensitive);
         pos = previousPos;
-        }
+      }
       else if (expanded.contains(envVarName) && envVarName != key)
-        {
+      {
         envVarValue = expanded[envVarName];
         value.replace(QString("<env:%1>").arg(envVarName), envVarValue, Qt::CaseInsensitive);
         pos = previousPos;
-        }
-      else if (this->SystemEnvironment.contains(envVarName))
-        {
-        value = this->SystemEnvironment.value(envVarName);
-        }
-      else
-        {
-        value = QString("<env-NOTFOUND:%1>").arg(envVarName);
-        }
-      previousPos = pos;
       }
-    expanded[key] = this->expandPlaceHolders(value);
+      else if (this->SystemEnvironment.contains(envVarName))
+      {
+        value = this->SystemEnvironment.value(envVarName);
+      }
+      else
+      {
+        value = QString("<env-NOTFOUND:%1>").arg(envVarName);
+      }
+      previousPos = pos;
     }
+    expanded[key] = this->expandPlaceHolders(value);
+  }
 
   // Update only variables explicitly listed in the settings
   foreach(const QString& envVarName, envVarNames)
-    {
+  {
     this->MapOfExpandedEnvVars[envVarName] = expanded[envVarName];
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -440,15 +440,15 @@ QString ctkAppLauncherSettings::userAdditionalSettingsDir()const
   Q_D(const ctkAppLauncherSettings);
   QString userAdditionalSettingsFileName = d->findUserAdditionalSettings();
   if (!userAdditionalSettingsFileName.isEmpty())
-    {
+  {
     return QFileInfo(userAdditionalSettingsFileName).absolutePath();
-    }
+  }
   else
-    {
+  {
     // No user settings file is found, return default location
     QFileInfo fileInfo(QSettings().fileName());
     return fileInfo.path();
-    }
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -493,9 +493,9 @@ bool ctkAppLauncherSettings::readSettings(const QString& fileName)
 
   // Read regular settings
   if (!d->checkSettings(fileName, ctkAppLauncherSettingsPrivate::RegularSettings))
-    {
+  {
     return false;
-    }
+  }
 
   d->LauncherSettingsDirs[ctkAppLauncherSettingsPrivate::RegularSettings] = QFileInfo(fileName).absolutePath();
 
@@ -507,30 +507,30 @@ bool ctkAppLauncherSettings::readSettings(const QString& fileName)
   // Read user additional settings
   QString userAdditionalSettingsFileName = this->findUserAdditionalSettings();
   if(!userAdditionalSettingsFileName.isEmpty())
-    {
+  {
     if (!d->checkSettings(userAdditionalSettingsFileName, ctkAppLauncherSettingsPrivate::UserAdditionalSettings))
-      {
+    {
       return false;
-      }
+    }
     d->LauncherSettingsDirs[ctkAppLauncherSettingsPrivate::UserAdditionalSettings] = QFileInfo(userAdditionalSettingsFileName).absolutePath();
     ctkAppLauncherSettingsPrivate::ScopedLauncherSettingsDir scopedLauncherSettingsDir(d, ctkAppLauncherSettingsPrivate::UserAdditionalSettings);
     Q_UNUSED(scopedLauncherSettingsDir);
     QSettings userAdditionalSettings(userAdditionalSettingsFileName, QSettings::IniFormat);
     d->readPathSettings(userAdditionalSettings);
-    }
+  }
 
   // Read additional settings
   if(!this->additionalSettingsFilePath().isEmpty())
-    {
+  {
     if (!d->checkSettings(this->additionalSettingsFilePath(), ctkAppLauncherSettingsPrivate::AdditionalSettings))
-      {
+    {
       return false;
-      }
+    }
     ctkAppLauncherSettingsPrivate::ScopedLauncherSettingsDir scopedLauncherSettingsDir(d, ctkAppLauncherSettingsPrivate::AdditionalSettings);
     Q_UNUSED(scopedLauncherSettingsDir);
     QSettings additionalSettings(this->additionalSettingsFilePath(), QSettings::IniFormat);
     d->readPathSettings(additionalSettings, this->additionalSettingsExcludeGroups());
-    }
+  }
 
   return true;
 }
@@ -554,9 +554,9 @@ void ctkAppLauncherSettings::setAdditionalSettingsFilePath(const QString& filePa
 {
   Q_D(ctkAppLauncherSettings);
   if (!filePath.isEmpty())
-    {
+  {
     d->LauncherSettingsDirs[ctkAppLauncherSettingsPrivate::AdditionalSettings] = QFileInfo(filePath).absolutePath();
-    }
+  }
   d->AdditionalSettingsFilePath = filePath;
 }
 
@@ -580,9 +580,9 @@ QStringList ctkAppLauncherSettings::libraryPaths(bool expand /* = true */)const
   Q_D(const ctkAppLauncherSettings);
   QStringList expanded;
   foreach(const QString& path, d->ListOfLibraryPaths)
-    {
+  {
     expanded << (expand ? d->resolvePath(d->expandValue(path)) : path);
-    }
+  }
   return expanded;
 }
 
@@ -592,9 +592,9 @@ QStringList ctkAppLauncherSettings::paths(bool expand /* = true */)const
   Q_D(const ctkAppLauncherSettings);
   QStringList expanded;
   foreach(const QString& path, d->ListOfPaths)
-    {
+  {
     expanded << (expand ? d->resolvePath(d->expandValue(path)) : path);
-    }
+  }
   return expanded;
 }
 
@@ -605,18 +605,18 @@ QString ctkAppLauncherSettings::envVar(const QString& variableName, bool expand 
   QString value = expand ? d->MapOfExpandedEnvVars[variableName] : d->MapOfEnvVars[variableName];
 
   if (d->MapOfPathVars.contains(variableName))
-    {
+  {
     QStringList paths = this->additionalPaths(variableName, expand);
     QString pathsAsStr = paths.join(d->PathSep);
     if (value.isEmpty())
-      {
+    {
       value = pathsAsStr;
-      }
-    else
-      {
-      value = QString("%1%2%3").arg(pathsAsStr, d->PathSep, value);
-      }
     }
+    else
+    {
+      value = QString("%1%2%3").arg(pathsAsStr, d->PathSep, value);
+    }
+  }
 
   return value;
 }
@@ -647,9 +647,9 @@ QStringList ctkAppLauncherSettings::additionalPaths(const QString& variableName,
   Q_D(const ctkAppLauncherSettings);
   QStringList expanded;
   foreach(const QString& path, d->MapOfPathVars.value(variableName))
-    {
+  {
     expanded << (expand ? d->resolvePath(d->expandValue(path)) : path);
-    }
+  }
   return expanded;
 }
 
@@ -659,9 +659,9 @@ QHash<QString, QStringList> ctkAppLauncherSettings::additionalPathsVars(bool exp
   Q_D(const ctkAppLauncherSettings);
   QHash<QString, QStringList> newVars;
   foreach(const QString& varName, d->MapOfPathVars.keys())
-    {
+  {
     newVars.insert(varName, this->additionalPaths(varName, expand));
-    }
+  }
   return newVars;
 }
 

--- a/Base/ctkAppLauncherSettings_p.h
+++ b/Base/ctkAppLauncherSettings_p.h
@@ -29,11 +29,11 @@ public:
 
   /// Different type of settings files.
   enum SettingsType
-    {
+  {
     RegularSettings = 0,    ///< Primary settings file associated with the launcher.
     UserAdditionalSettings, ///< Settings file implicitly associated using application `name`, `organizationName`, `organizationDomain`, and optionally `revision`.
     AdditionalSettings      ///< Settings file explicitly specified using command line argument.
-    };
+  };
   static QString settingsTypeToString(const SettingsType& settingsType);
 
   static QString settingsDirPlaceHolder(const SettingsType& settingsType);

--- a/Base/ctkCommandLineParser.cpp
+++ b/Base/ctkCommandLineParser.cpp
@@ -54,47 +54,47 @@ public:
       Deprecated(deprecated), DefaultValue(defaultValue), Value(type), ValueType(type)
   {
     if (defaultValue.isValid())
-      {
+    {
       Value = defaultValue;
-      }
+    }
 
     switch (type)
-      {
+    {
       case QVariant::String:
-        {
+      {
         NumberOfParametersToProcess = 1;
         RegularExpression = ".*";
-        }
+      }
         break;
       case QVariant::Bool:
-        {
+      {
         NumberOfParametersToProcess = 0;
         RegularExpression = "";
-        }
+      }
         break;
       case QVariant::StringList:
-        {
+      {
         NumberOfParametersToProcess = -1;
         RegularExpression = ".*";
-        }
+      }
         break;
       case QVariant::Int:
-        {
+      {
         NumberOfParametersToProcess = 1;
         RegularExpression = "-?[0-9]+";
         ExactMatchFailedMessage = "A negative or positive integer is expected.";
-        }
+      }
         break;
       case QVariant::Double:
-        {
+      {
         NumberOfParametersToProcess = 1;
         RegularExpression = "-?[0-9]*\\.?[0-9]+";
         ExactMatchFailedMessage = "A double is expected.";
-        }
+      }
         break;
       default:
         ExactMatchFailedMessage = QString("Type %1 not supported.").arg(static_cast<int>(type));
-      }
+    }
 
   }
 
@@ -124,56 +124,56 @@ public:
 bool CommandLineParserArgumentDescription::addParameter(const QString& value)
 {
   if (!RegularExpression.isEmpty())
-    {
+  {
     // Validate value
     QRegExp regexp(this->RegularExpression);
     if (!regexp.exactMatch(value))
-      {
+    {
       return false;
-      }
     }
+  }
 
   switch (Value.type())
-    {
+  {
     case QVariant::String:
-      {
+    {
       Value.setValue(value);
-      }
+    }
       break;
     case QVariant::Bool:
-      {
+    {
       Value.setValue(!QString::compare(value, "true", Qt::CaseInsensitive));
-      }
+    }
       break;
     case QVariant::StringList:
-      {
+    {
       if (Value.isNull())
-        {
+      {
         QStringList list;
         list << value;
         Value.setValue(list);
-        }
+      }
       else
-        {
+      {
         QStringList list = Value.toStringList();
         list << value;
         Value.setValue(list);
-        }
       }
+    }
       break;
     case QVariant::Int:
-      {
+    {
       Value.setValue(value.toInt());
-      }
+    }
       break;
     case QVariant::Double:
-      {
+    {
       Value.setValue(value.toDouble());
-      }
+    }
       break;
     default:
       return false;
-    }
+  }
 
   return true;
 }
@@ -189,40 +189,40 @@ QString CommandLineParserArgumentDescription::helpText(int fieldWidth, const cha
 
   QString shortAndLongArg;
   if (!this->ShortArg.isEmpty())
-    {
+  {
     shortAndLongArg += QString("  %1%2").arg(this->ShortArgPrefix).arg(this->ShortArg);
-    }
+  }
 
   if (!this->LongArg.isEmpty())
-    {
+  {
     if (this->ShortArg.isEmpty())
-      {
+    {
       shortAndLongArg.append("  ");
-      }
+    }
     else
-      {
+    {
       shortAndLongArg.append(", ");
-      }
+    }
 
     shortAndLongArg += QString("%1%2").arg(this->LongArgPrefix).arg(this->LongArg);
-    }
+  }
 
   if(!this->ArgHelp.isEmpty())
-    {
+  {
     stream.setFieldWidth(fieldWidth);
-    }
+  }
 
   stream  << shortAndLongArg;
   stream.setFieldWidth(0);
   stream << this->ArgHelp;
   if (!settingsValue.isNull())
-    {
+  {
     stream << " (default: " << settingsValue << ")";
-    }
+  }
   else if (!this->DefaultValue.isNull())
-    {
+  {
     stream << " (default: " << this->DefaultValue.toString() << ")";
-    }
+  }
   stream << "\n";
   return text;
 }
@@ -274,30 +274,30 @@ CommandLineParserArgumentDescription*
 {
   QString unprefixedArg = argument;
   if (!LongPrefix.isEmpty() && argument.startsWith(LongPrefix))
-    {
+  {
     // Case when (ShortPrefix + UnPrefixedArgument) matches LongPrefix
     if (argument == LongPrefix && !ShortPrefix.isEmpty() && argument.startsWith(ShortPrefix))
-      {
+    {
       unprefixedArg = argument.mid(ShortPrefix.length());
-      }
+    }
     else
-      {
+    {
       unprefixedArg = argument.mid(LongPrefix.length());
-      }
     }
+  }
   else if (!ShortPrefix.isEmpty() && argument.startsWith(ShortPrefix))
-    {
+  {
     unprefixedArg = argument.mid(ShortPrefix.length());
-    }
+  }
   else if (!LongPrefix.isEmpty() && !ShortPrefix.isEmpty())
-    {
+  {
     return 0;
-    }
+  }
 
   if (this->ArgNameToArgumentDescriptionMap.contains(unprefixedArg))
-    {
+  {
     return this->ArgNameToArgumentDescriptionMap[unprefixedArg];
-    }
+  }
   return 0;
 }
 
@@ -333,13 +333,13 @@ QHash<QString, QVariant> ctkCommandLineParser::parseArguments(const QStringList&
   this->Internal->ErrorString.clear();
   foreach (CommandLineParserArgumentDescription* desc,
            this->Internal->ArgumentDescriptionList)
-    {
+  {
     desc->Value = QVariant(desc->ValueType);
     if (desc->DefaultValue.isValid())
-      {
+    {
       desc->Value = desc->DefaultValue;
-      }
     }
+  }
 
   bool error = false;
   bool ignoreRest = false;
@@ -347,120 +347,120 @@ QHash<QString, QVariant> ctkCommandLineParser::parseArguments(const QStringList&
   CommandLineParserArgumentDescription * currentArgDesc = 0;
   QList<CommandLineParserArgumentDescription*> parsedArgDescriptions;
   for(int i = 1; i < arguments.size(); ++i)
-    {
+  {
     QString argument = arguments.at(i);
     if (this->Internal->Debug) { qDebug() << "Processing" << argument; }
 
     // should argument be ignored ?
     if (ignoreRest)
-      {
+    {
       if (this->Internal->Debug)
-        {
+      {
         qDebug() << "  Skipping: IgnoreRest flag was been set";
-        }
+      }
       this->Internal->UnparsedArguments << argument;
       continue;
-      }
+    }
 
     // Skip if the argument does not start with the defined prefix
     if (!(argument.startsWith(this->Internal->LongPrefix)
       || argument.startsWith(this->Internal->ShortPrefix)))
-      {
+    {
       if (this->Internal->StrictMode)
-        {
+      {
         this->Internal->ErrorString = QString("Unknown argument %1").arg(argument);
         error = true;
         break;
-        }
+      }
       if (this->Internal->Debug)
-        {
+      {
         qDebug() << "  Skipping: It does not start with the defined prefix";
-        }
+      }
       this->Internal->UnparsedArguments << argument;
       continue;
-      }
+    }
 
     // Skip if argument has already been parsed ...
     if (this->Internal->ProcessedArguments.contains(argument))
-      {
+    {
       if (this->Internal->StrictMode)
-        {
+      {
         this->Internal->ErrorString = QString("Argument %1 already processed !").arg(argument);
         error = true;
         break;
-        }
-      if (this->Internal->Debug)
-        {
-        qDebug() << "  Skipping: Already processed !";
-        }
-      continue;
       }
+      if (this->Internal->Debug)
+      {
+        qDebug() << "  Skipping: Already processed !";
+      }
+      continue;
+    }
 
     // Retrieve corresponding argument description
     currentArgDesc = this->Internal->argumentDescription(argument);
 
     // Is there a corresponding argument description ?
     if (currentArgDesc)
-      {
+    {
       // If the argument is deprecated, print the help text but continue processing
       if (currentArgDesc->Deprecated)
-        {
+      {
         qWarning().nospace() << "Deprecated argument " << argument << ": "  << currentArgDesc->ArgHelp;
-        }
+      }
       else
-        {
+      {
         parsedArgDescriptions.push_back(currentArgDesc);
-        }
+      }
 
       // Is the argument the special "disable QSettings" argument?
       if ((!currentArgDesc->LongArg.isEmpty() && currentArgDesc->LongArg == this->Internal->DisableQSettingsLongArg)
         || (!currentArgDesc->ShortArg.isEmpty() && currentArgDesc->ShortArg == this->Internal->DisableQSettingsShortArg))
-        {
+      {
         useSettings = false;
-        }
+      }
 
       this->Internal->ProcessedArguments << currentArgDesc->ShortArg << currentArgDesc->LongArg;
       int numberOfParametersToProcess = currentArgDesc->NumberOfParametersToProcess;
       ignoreRest = currentArgDesc->IgnoreRest;
       if (this->Internal->Debug && ignoreRest)
-        {
+      {
         qDebug() << "  IgnoreRest flag is True";
-        }
+      }
 
       // Is the number of parameters associated with the argument being processed known ?
       if (numberOfParametersToProcess == 0)
-        {
+      {
         currentArgDesc->addParameter("true");
-        }
+      }
       else if (numberOfParametersToProcess > 0)
-        {
+      {
         QString missingParameterError =
             "Argument %1 has %2 value(s) associated whereas exactly %3 are expected.";
         for(int j=1; j <= numberOfParametersToProcess; ++j)
-          {
+        {
           if (i + j >= arguments.size())
-            {
+          {
             this->Internal->ErrorString =
                 missingParameterError.arg(argument).arg(j-1).arg(numberOfParametersToProcess);
             if (this->Internal->Debug) { qDebug() << this->Internal->ErrorString; }
             if (ok) { *ok = false; }
             return QHash<QString, QVariant>();
-            }
+          }
           QString parameter = arguments.at(i + j);
           if (this->Internal->Debug)
-            {
+          {
             qDebug() << "  Processing parameter" << j << ", value:" << parameter;
-            }
+          }
           if (this->argumentAdded(parameter))
-            {
+          {
             this->Internal->ErrorString =
                 missingParameterError.arg(argument).arg(j-1).arg(numberOfParametersToProcess);
             if (this->Internal->Debug) { qDebug() << this->Internal->ErrorString; }
             if (ok) { *ok = false; }
             return QHash<QString, QVariant>();
-            }
+          }
           if (!currentArgDesc->addParameter(parameter))
-            {
+          {
             this->Internal->ErrorString = QString(
                 "Value(s) associated with argument %1 are incorrect. %2").
                 arg(argument).arg(currentArgDesc->ExactMatchFailedMessage);
@@ -468,35 +468,35 @@ QHash<QString, QVariant> ctkCommandLineParser::parseArguments(const QStringList&
             if (this->Internal->Debug) { qDebug() << this->Internal->ErrorString; }
             if (ok) { *ok = false; }
             return QHash<QString, QVariant>();
-            }
           }
+        }
         // Update main loop increment
         i = i + numberOfParametersToProcess;
-        }
+      }
       else if (numberOfParametersToProcess == -1)
-        {
+      {
         if (this->Internal->Debug)
-          {
+        {
           qDebug() << "  Processing StringList ...";
-          }
+        }
         int j = 1;
         while(j + i < arguments.size())
-          {
+        {
           if (this->argumentAdded(arguments.at(j + i)))
-            {
+          {
             if (this->Internal->Debug)
-              {
+            {
               qDebug() << "  No more parameter for" << argument;
-              }
-            break;
             }
+            break;
+          }
           QString parameter = arguments.at(j + i);
           if (this->Internal->Debug)
-            {
+          {
             qDebug() << "  Processing parameter" << j << ", value:" << parameter;
-            }
+          }
           if (!currentArgDesc->addParameter(parameter))
-            {
+          {
             this->Internal->ErrorString = QString(
                 "Value(s) associated with argument %1 are incorrect. %2").
                 arg(argument).arg(currentArgDesc->ExactMatchFailedMessage);
@@ -504,118 +504,118 @@ QHash<QString, QVariant> ctkCommandLineParser::parseArguments(const QStringList&
             if (this->Internal->Debug) { qDebug() << this->Internal->ErrorString; }
             if (ok) { *ok = false; }
             return QHash<QString, QVariant>();
-            }
-          j++;
           }
+          j++;
+        }
         // Update main loop increment
         i = i + j;
-        }
       }
+    }
     else
-      {
+    {
       if (this->Internal->StrictMode)
-        {
+      {
         this->Internal->ErrorString = QString("Unknown argument %1").arg(argument);
         error = true;
         break;
-        }
-      if (this->Internal->Debug)
-        {
-        qDebug() << "  Skipping: Unknown argument";
-        }
-      this->Internal->UnparsedArguments << argument;
       }
+      if (this->Internal->Debug)
+      {
+        qDebug() << "  Skipping: Unknown argument";
+      }
+      this->Internal->UnparsedArguments << argument;
     }
+  }
 
   if (ok)
-    {
+  {
     *ok = !error;
-    }
+  }
 
   QSettings* settings = 0;
   if (this->Internal->UseQSettings && useSettings)
-    {
+  {
     if (this->Internal->Settings)
-      {
+    {
       settings = this->Internal->Settings;
-      }
+    }
     else
-      {
+    {
       // Use a default constructed QSettings instance
       settings = new QSettings();
-      }
     }
+  }
 
   QHash<QString, QVariant> parsedArguments;
   QListIterator<CommandLineParserArgumentDescription*> it(this->Internal->ArgumentDescriptionList);
   while (it.hasNext())
-    {
+  {
     QString key;
     CommandLineParserArgumentDescription* desc = it.next();
     if (!desc->LongArg.isEmpty())
-      {
+    {
       key = desc->LongArg;
-      }
+    }
     else
-      {
+    {
       key = desc->ShortArg;
-      }
+    }
 
     if (parsedArgDescriptions.contains(desc))
-      {
+    {
       // The argument was supplied on the command line, so use the given value
 
       if (this->Internal->MergeSettings && settings)
-        {
+      {
         // Merge with QSettings
         QVariant settingsVal = settings->value(key);
 
         if (desc->ValueType == QVariant::StringList &&
             settingsVal.canConvert(QVariant::StringList))
-          {
+        {
           QStringList stringList = desc->Value.toStringList();
           stringList.append(settingsVal.toStringList());
           parsedArguments.insert(key, stringList);
-          }
+        }
         else
-          {
+        {
           // do a normal insert
           parsedArguments.insert(key, desc->Value);
-          }
-        }
-      else
-        {
-        // No merging, just insert all user values
-        parsedArguments.insert(key, desc->Value);
         }
       }
-    else
+      else
       {
+        // No merging, just insert all user values
+        parsedArguments.insert(key, desc->Value);
+      }
+    }
+    else
+    {
       if (settings)
-        {
+      {
         // If there is a valid QSettings entry for the argument, use the value
         QVariant settingsVal = settings->value(key, desc->Value);
         if (!settingsVal.isNull())
-          {
-          parsedArguments.insert(key, settingsVal);
-          }
-        }
-      else
         {
+          parsedArguments.insert(key, settingsVal);
+        }
+      }
+      else
+      {
         // Just insert the arguments with valid default values
         if (!desc->Value.isNull())
-          {
+        {
           parsedArguments.insert(key, desc->Value);
-          }
         }
       }
     }
+  }
 
   // If we created a default QSettings instance, delete it
   if (settings && !this->Internal->Settings)
-    {
+  {
     delete settings;
-    }
+  }
 
   return parsedArguments;
 }
@@ -627,9 +627,9 @@ QHash<QString, QVariant> ctkCommandLineParser::parseArguments(int argc, char** a
 
   // Create a QStringList of arguments
   for(int i = 0; i < argc; ++i)
-    {
+  {
     arguments << argv[i];
-    }
+  }
 
   return this->parseArguments(arguments, ok);
 }
@@ -677,22 +677,22 @@ void ctkCommandLineParser::addArgument(const QString& longarg, const QString& sh
 
   int argWidth = 0;
   if (!longarg.isEmpty())
-    {
+  {
     this->Internal->ArgNameToArgumentDescriptionMap[longarg] = argDesc;
     argWidth += longarg.length() + this->Internal->LongPrefix.length();
-    }
+  }
   if (!shortarg.isEmpty())
-    {
+  {
     this->Internal->ArgNameToArgumentDescriptionMap[shortarg] = argDesc;
     argWidth += shortarg.length() + this->Internal->ShortPrefix.length() + 2;
-    }
+  }
   argWidth += 5;
 
   // Set the field width for the arguments
   if (argWidth > this->Internal->FieldWidth)
-    {
+  {
     this->Internal->FieldWidth = argWidth;
-    }
+  }
 
   this->Internal->ArgumentDescriptionList << argDesc;
   this->Internal->GroupToArgumentDescriptionListMap[this->Internal->CurrentGroup] << argDesc;
@@ -712,14 +712,14 @@ bool ctkCommandLineParser::setExactMatchRegularExpression(
   CommandLineParserArgumentDescription * argDesc =
       this->Internal->argumentDescription(argument);
   if (!argDesc)
-    {
+  {
     return false;
-    }
+  }
 
   if (argDesc->Value.type() == QVariant::Bool)
-    {
+  {
     return false;
-    }
+  }
   argDesc->RegularExpression = expression;
   argDesc->ExactMatchFailedMessage = exactMatchFailedMessage;
   return true;
@@ -775,48 +775,48 @@ QString ctkCommandLineParser::helpText(const char charPad) const
   QMapIterator<QString, QList<CommandLineParserArgumentDescription*> > it(
       this->Internal->GroupToArgumentDescriptionListMap);
   while(it.hasNext())
-    {
+  {
     it.next();
     if (!it.key().isEmpty())
-      {
+    {
       stream << "\n" << it.key() << "\n";
-      }
+    }
     foreach(CommandLineParserArgumentDescription* argDesc, it.value())
-      {
+    {
       if (argDesc->Deprecated)
-        {
+      {
         deprecatedArgs << argDesc;
-        }
+      }
       else
-        {
+      {
         // Extract associated value from settings if any
         QString settingsValue;
         if (this->Internal->Settings)
-          {
+        {
           QString key;
           if (!argDesc->LongArg.isEmpty())
-            {
+          {
             key = argDesc->LongArg;
-            }
-          else
-            {
-            key = argDesc->ShortArg;
-            }
-          settingsValue = this->Internal->Settings->value(key).toString();
           }
-        stream << argDesc->helpText(this->Internal->FieldWidth, charPad, settingsValue);
+          else
+          {
+            key = argDesc->ShortArg;
+          }
+          settingsValue = this->Internal->Settings->value(key).toString();
         }
+        stream << argDesc->helpText(this->Internal->FieldWidth, charPad, settingsValue);
       }
     }
+  }
 
   if (!deprecatedArgs.empty())
-    {
+  {
     stream << "\nDeprecated arguments:\n";
     foreach(CommandLineParserArgumentDescription* argDesc, deprecatedArgs)
-      {
+    {
       stream << argDesc->helpText(this->Internal->FieldWidth, charPad);
-      }
     }
+  }
 
   return text;
 }
@@ -864,9 +864,9 @@ void ctkCommandLineParser::convertWindowsCommandLineToUnixArguments(
   PWSTR cmd_line, int* argc, char*** argv)
 {
   if (!cmd_line || !argc || !argv)
-    {
+  {
     return;
-    }
+  }
   *argc = 0;
   *argv = nullptr;
 
@@ -923,5 +923,5 @@ void ctkCommandLineParser::convertWindowsCommandLineToUnixArguments(
   WideCharToMultiByte(CP_UTF8, 0, wideBuffer, wideLength, utf8buffer, utf8length, NULL, NULL);
   utf8buffer[utf8length] = '\0'; // Make sure the string is null-terminated
   (*argv)[0] = utf8buffer;
- }
+}
 #endif

--- a/Base/ctkSettingsHelper.cpp
+++ b/Base/ctkSettingsHelper.cpp
@@ -9,34 +9,34 @@
 // --------------------------------------------------------------------------
 QStringList ctk::readArrayValues(
   QSettings& settings, const QString& arrayName, const QString fieldName)
-  {
+{
   Q_ASSERT(!arrayName.isEmpty());
   Q_ASSERT(!fieldName.isEmpty());
   QStringList listOfValues;
   int size = settings.beginReadArray(arrayName);
   for (int i=0; i < size; ++i)
-    {
+  {
     settings.setArrayIndex(i);
     listOfValues << settings.value(fieldName).toString();
-    }
+  }
   settings.endArray();
   return listOfValues;
-  }
+}
 
 // --------------------------------------------------------------------------
 QHash<QString, QString> ctk::readKeyValuePairs(QSettings& settings,
   const QString& groupName)
-  {
+{
   Q_ASSERT(!groupName.isEmpty());
   QHash<QString, QString> keyValuePairs;
   settings.beginGroup(groupName);
   foreach(const QString& key, settings.childKeys())
-    {
+  {
     keyValuePairs[key] = settings.value(key).toString();
-    }
+  }
   settings.endGroup();
   return keyValuePairs;
-  }
+}
 
 // --------------------------------------------------------------------------
 void ctk::writeArrayValues(QSettings& settings, const QStringList& values,
@@ -46,10 +46,10 @@ void ctk::writeArrayValues(QSettings& settings, const QStringList& values,
   Q_ASSERT(!fieldName.isEmpty());
   settings.beginWriteArray(arrayName);
   for(int i=0; i < values.size(); ++i)
-    {
+  {
     settings.setArrayIndex(i);
     settings.setValue(fieldName, values.at(i));
-    }
+  }
   settings.endArray();
 }
 
@@ -60,8 +60,8 @@ void ctk::writeKeyValuePairs(QSettings& settings,
   Q_ASSERT(!groupName.isEmpty());
   settings.beginGroup(groupName);
   foreach(const QString& key, map.keys())
-    {
+  {
     settings.setValue(key, map[key]);
-    }
+  }
   settings.endGroup();
 }

--- a/Base/ctkTest.h
+++ b/Base/ctkTest.h
@@ -70,10 +70,10 @@ static void mouseEvent(QTest::MouseAction action, QWidget *widget, Qt::MouseButt
                        Qt::KeyboardModifiers stateKey, QPoint pos, int delay=-1)
 {
   if (action != QTest::MouseMove)
-    {
+  {
     QTest::mouseEvent(action, widget, button, stateKey, pos, delay);
     return;
-    }
+  }
   QTEST_ASSERT(widget);
   //extern int Q_TESTLIB_EXPORT defaultMouseDelay();
   //if (delay == -1 || delay < defaultMouseDelay())
@@ -94,12 +94,12 @@ static void mouseEvent(QTest::MouseAction action, QWidget *widget, Qt::MouseButt
   me = QMouseEvent(QEvent::MouseMove, pos, widget->mapToGlobal(pos), button, button, stateKey);
   QSpontaneKeyEvent::setSpontaneous(&me);
   if (!qApp->notify(widget, &me))
-    {
+  {
     static const char *mouseActionNames[] =
         { "MousePress", "MouseRelease", "MouseClick", "MouseDClick", "MouseMove" };
     QString warning = QLatin1String("Mouse event \"%1\" not accepted by receiving widget");
     QTest::qWarn(warning.arg(QLatin1String(mouseActionNames[static_cast<int>(action)])).toLocal8Bit());
-    }
+  }
 }
 
 inline void mouseMove(QWidget *widget, Qt::MouseButton button, Qt::KeyboardModifiers stateKey = 0,

--- a/Main.cpp
+++ b/Main.cpp
@@ -125,9 +125,9 @@ int appLauncherMain(int argc, char** argv)
   // "CTKAppLauncher.exe" or just "CTKAppLauncher"). Make sure here that executable
   // path includes file extension so that the file can be found.
   if (!executableName.toLower().endsWith(".exe"))
-    {
+  {
     executableName.append(".exe");
-    }
+  }
 #endif
 
   QFileInfo launcherFile(QDir::current(), executableName);
@@ -137,24 +137,24 @@ int appLauncherMain(int argc, char** argv)
   QScopedPointer<ctkAppLauncher> appLauncher(new ctkAppLauncher);
   appLauncher->setArguments(appArguments.arguments());
   if (!appLauncher->initialize(launcherFile.absoluteFilePath()))
-    {
+  {
     return EXIT_FAILURE;
-    }
+  }
   int status = appLauncher->configure();
   if (status != ctkAppLauncher::Continue)
-    {
+  {
     return status == ctkAppLauncher::ExitWithSuccess ? EXIT_SUCCESS : EXIT_FAILURE;
-    }
+  }
 
   QScopedPointer<QCoreApplication> app;
   if (appLauncher->disableSplash())
-    {
+  {
     app.reset(new QCoreApplication(
                 appArguments.argumentCount(ctkAppArguments::ARG_REGULAR_LIST),
                 appArguments.argumentValues(ctkAppArguments::ARG_REGULAR_LIST)));
-    }
+  }
   else
-    {
+  {
     // Initialize platform plugin in static build
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) && defined Q_OS_WIN32 && defined QT_STATIC)
     Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
@@ -166,7 +166,7 @@ int appLauncherMain(int argc, char** argv)
     app.reset(new QApplication(
                 appArguments.argumentCount(ctkAppArguments::ARG_REGULAR_LIST),
                 appArguments.argumentValues(ctkAppArguments::ARG_REGULAR_LIST)));
-    }
+  }
 
   appLauncher.reset(new ctkAppLauncher);
   appLauncher->setArguments(appArguments.arguments());
@@ -214,9 +214,9 @@ int __stdcall wWinMain(HINSTANCE hInstance,
   int ret = appLauncherMain(argc, argv);
 
   for (int i = 0; i < argc; ++i)
-    {
+  {
     delete [] argv[i];
-    }
+  }
   delete [] argv;
 
   return ret;

--- a/Testing/Launcher/App4Test/Main.cpp.in
+++ b/Testing/Launcher/App4Test/Main.cpp.in
@@ -21,10 +21,10 @@ inline std::string currentWorkingDirectory()
   char * currentPath = _getcwd(NULL, 0);
   std::string currentPathAsStr;
   if (currentPath)
-    {
+  {
     currentPathAsStr = std::string(currentPath);
     free(currentPath);
-    }
+  }
   std::replace(currentPathAsStr.begin(), currentPathAsStr.end(), '\\', '/');
   return currentPathAsStr;
 }
@@ -40,10 +40,10 @@ inline std::string currentWorkingDirectory()
   char * currentPath = getcwd(NULL, 0);
   std::string currentPathAsStr;
   if (currentPath)
-    {
+  {
     currentPathAsStr = std::string(currentPath);
     free(currentPath);
-    }
+  }
   return currentPathAsStr;
 }
 #endif
@@ -52,20 +52,20 @@ int check_env_var(const char* varname, const char* expected_value)
 {
   char * varStr = getenv(varname);
   if (!varStr)
-    {
+  {
     std::cout << "Failed to retrieve '" << varname << "' env. variable !" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   std::string var(varStr);
   std::string expectedVar(expected_value);
   if (var != expectedVar)
-    {
+  {
     std::cout << "Failed to load the saved environment:"
               << "\n\texpected: " << expectedVar
               << "\n\t current: " << var
               << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   return EXIT_SUCCESS;
 }
 
@@ -73,10 +73,10 @@ int check_unexpected_env_var(const char* varname)
 {
   char * varStr = getenv(varname);
   if (varStr)
-    {
+  {
     std::cout << "Environment variable '" << varname << "' with value [" << varStr << "] is unexpected !" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   return EXIT_SUCCESS;
 }
 
@@ -86,13 +86,13 @@ void display_arguments(std::ostream& stream, int argc, char* argv[])
   // the following may require to update the tests.
   stream << "Argument passed:";
   if (argc >= 2)
-    {
+  {
     stream << argv[1]; // argName
-    }
+  }
   for(int idx=2; idx < argc; idx++)
-    {
+  {
     stream << " " << argv[idx];
-    }
+  }
   stream << std::endl;
 }
 
@@ -103,15 +103,15 @@ int main(int argc, char** argv)
   bool verboseLibInstantiation = true;
 
   if (argc > 1)
-    {
+  {
     std::string argName(argv[1]);
     if (argName == "--foo")
-      {
+    {
       std::cout << "Argument count: " << argc << " - ";
       display_arguments(std::cout, argc, argv);
-      }
+    }
     else if (argName == "--test-timeout")
-      {
+    {
       int timeout = 3;
       std::cout << "App4Test will exit in " << timeout
                 << " seconds with error_code=" << timeout << std::endl;
@@ -128,19 +128,19 @@ int main(int argc, char** argv)
       timeoutFile.close();
       std::cout << "Generated: " << filename << std::endl;
       return timeout;
-      }
+    }
     else if (argName == "--forever")
-      {
+    {
       std::cout << "App4Test - Forever" << std::endl;
       while(true){}
-      }
+    }
     else if (argName == "--check-path")
-      {
+    {
       char * path = getenv("PATH");
       std::cout << "PATH=" << (path ? path : "NULL") << std::endl;
-      }
+    }
     else if (argName == "--check-env")
-      {
+    {
       std::cout << std::endl;
       char * env1 = getenv("SOMETHING_NICE");
       std::cout << "SOMETHING_NICE=" << (env1 ? env1 : "NULL") << std::endl;
@@ -150,111 +150,111 @@ int main(int argc, char** argv)
       std::cout << "SOMETHING_GREAT=" << (env3 ? env3 : "NULL") << std::endl;
       char * env4 = getenv("SOME_PATH");
       std::cout << "SOME_PATH=" << (env4 ? env4 : "NULL") << std::endl;
-      }
+    }
     else if (argName == "--print-current-working-directory")
-      {
+    {
       std::cout << "currentWorkingDirectory=" << currentWorkingDirectory() << std::endl;
-      }
+    }
     else if (argName == "--print-hello-world")
-      {
+    {
       std::cout << "Hello world !" << std::endl;
-      }
+    }
     else if (argName == "--exit-failure")
-      {
+    {
       std::cout << "Exit failure !" << std::endl;
       return EXIT_FAILURE;
-      }
+    }
     else if (argName == "--long-help")
-      {
+    {
       verboseLibInstantiation = false;
       std::cout << "This is the long help" << std::endl;
-      }
+    }
     else if (argName == "-sh")
-      {
+    {
       verboseLibInstantiation = false;
       std::cout << "This is the short help" << std::endl;
-      }
+    }
     else if (argName == "--check-environment-load")
-      {
+    {
       verboseLibInstantiation = false;
       if (check_env_var(
             /* varname= */ "VAR_FOR_ENV_LOAD_TEST",
             /* expected_value= */ "set-from-level-0") != EXIT_SUCCESS)
-        {
+      {
         return EXIT_FAILURE;
-        }
+      }
       if (check_env_var(
             /* varname= */ "VAR_FROM_SETTINGS",
             /* expected_value= */ "set-from-settings") != EXIT_SUCCESS)
-        {
+      {
         return EXIT_FAILURE;
-        }
+      }
 
       // Check that the loaded environment is also saved
       if (check_unexpected_env_var(
             /* varname= */ "APPLAUNCHER_LEVEL") != EXIT_SUCCESS)
-        {
-        return EXIT_FAILURE;
-        }
-      }
-    else if (argName == "--check-environment-load-level1")
       {
+        return EXIT_FAILURE;
+      }
+    }
+    else if (argName == "--check-environment-load-level1")
+    {
       verboseLibInstantiation = false;
       if (check_env_var(
             /* varname= */ "VAR_FOR_ENV_LOAD_TEST",
             /* expected_value= */ "set-from-level-1") != EXIT_SUCCESS)
-        {
+      {
         return EXIT_FAILURE;
-        }
+      }
       if (check_env_var(
             /* varname= */ "VAR_FROM_SETTINGS",
             /* expected_value= */ "set-from-settings") != EXIT_SUCCESS)
-        {
+      {
         return EXIT_FAILURE;
-        }
+      }
       // Check that the loaded environment is also saved
       if (check_env_var(
             /* varname= */ "APPLAUNCHER_LEVEL",
             /* expected_value= */ "1") != EXIT_SUCCESS)
-        {
-        return EXIT_FAILURE;
-        }
-      }
-    else if (argName == "--check-reserved-argument")
       {
+        return EXIT_FAILURE;
+      }
+    }
+    else if (argName == "--check-reserved-argument")
+    {
       std::string expectedArgName2("-widgetcount");
       int expectedArgCount = 3;
       if (argc != expectedArgCount)
-        {
+      {
         std::cerr << "Unexpected number of arguments"
                   << "\n\texpected: " << expectedArgCount
                   << "\n\t current: " << argc
                   << std::endl;
         std::cerr << "Argument passed:" << argName;
         for(int i=2; i < argc; i++)
-          {
+        {
           std::cerr << " " << argv[i];
-          }
+        }
         std::cerr << std::endl;
         return EXIT_FAILURE;
-        }
+      }
       std::string argName2(argv[2]);
       if (argName2 != expectedArgName2)
-        {
+      {
         std::cerr << "Unexpected argument #2:"
           << "\n\texpected: " << expectedArgName2
           << "\n\t current: " << argName2
           << std::endl;
         display_arguments(std::cerr, argc, argv);
         return EXIT_FAILURE;
-        }
-      std::cout << expectedArgName2 << " argument passed" << std::endl;
       }
+      std::cout << expectedArgName2 << " argument passed" << std::endl;
     }
+  }
   else if (argc == 1)
-    {
+  {
     std::cout << "No argument provided" << std::endl;
-    }
+  }
 
   // Instantiate library objects
 @LIB_INSTANCIATES@

--- a/Testing/Launcher/App4Test/lib.template/app4TestLib.cpp.in
+++ b/Testing/Launcher/App4Test/lib.template/app4TestLib.cpp.in
@@ -21,9 +21,9 @@ void wait(double seconds)
 app4TestLib@LIBSUFFIX@::app4TestLib@LIBSUFFIX@(bool verbose)
 {
   if (verbose)
-    {
+  {
     std::cout<<"Instantiate " << "app4TestLib@LIBSUFFIX@" << std::endl;
-    }
+  }
   app4TestLib::wait(0.02);
 }
 

--- a/Testing/LauncherLib/AppWithLauncherLib/main.cpp
+++ b/Testing/LauncherLib/AppWithLauncherLib/main.cpp
@@ -47,11 +47,11 @@ int checkReadArrayValues()
 {
   QSettings settings("settings-for-read-array-values-test.ini", QSettings::IniFormat);
   if (!QFile(settings.fileName()).exists())
-    {
+  {
     qWarning() << "Line" << __LINE__ << __FILE__ << "\n"
                << "Settings file" << settings.fileName() << "does not exist";
     return EXIT_FAILURE;
-    }
+  }
 
   CHECK_QSTRINGLIST(
         ctk::readArrayValues(settings, "Paths", "path"),
@@ -220,14 +220,14 @@ int checkReadSettingsWithoutExpand()
   int expectedPathsEnvVarsCount = 4;
 #endif
   if (pathsEnvVars.count() != expectedPathsEnvVarsCount)
-    {
+  {
     qWarning() << "Line" << __LINE__ << __FILE__ << "\n"
                << "pathsEnvVars has not the expected number of entries\n"
                << "current:" << pathsEnvVars.count() << "\n"
                << "expected:" << expectedPathsEnvVarsCount << "\n"
                << "current list:" << pathsEnvVars;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }
@@ -415,14 +415,14 @@ int checkReadSettingsWithExpand()
   int expectedPathsEnvVarsCount = 4;
 #endif
   if (pathsEnvVars.count() != expectedPathsEnvVarsCount)
-    {
+  {
     qWarning() << "Line" << __LINE__ << __FILE__ << "\n"
                << "pathsEnvVars has not the expected number of entries\n"
                << "current:" << pathsEnvVars.count() << "\n"
                << "expected:" << expectedPathsEnvVarsCount << "\n"
                << "current list:" << pathsEnvVars;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }
@@ -442,9 +442,9 @@ int checkReadAdditionalSettingsWithExpand()
   QString userAdditionalSettingsFileName =
       createUserAdditionalLauncherSettings("AwesomeAppXXXXXX-0.1", appName, success);
   if (!success)
-    {
+  {
     return EXIT_FAILURE;
-    }
+  }
 
   // Update main settings replacing "AwesomeApp" with "AwesomeAppXXXXXX"
   QString mainSettingsFileName("launcher-settings.ini");
@@ -456,9 +456,9 @@ int checkReadAdditionalSettingsWithExpand()
   // Generate user additional settings
   QFile userAdditionalSettingsFile(userAdditionalSettingsFileName);
   if (!userAdditionalSettingsFile.open(QIODevice::WriteOnly))
-    {
+  {
     qWarning() << "Line" << __LINE__ << "- Failed to open user additional settings file" << userAdditionalSettingsFileName;
-    }
+  }
   QString userAdditionalSettingsContent = readFile(__LINE__, "launcher-user-additional-settings.ini");
   CHECK_QSTRING_NOT_NULL(userAdditionalSettingsContent);
   QTextStream outputStream(&userAdditionalSettingsFile);
@@ -574,15 +574,15 @@ int checkEnvironment(bool withLauncher)
   CHECK_BOOL(systemEnvironment.contains("APPLAUNCHER_LEVEL"), withLauncher);
 
   if (withLauncher)
-    {
+  {
     CHECK_INT(ctkAppLauncherEnvironment::currentLevel(), 1);
     CHECK_QSTRING(systemEnvironment.value("APPWITHLAUNCHER_ENV_VAR", ""), "set-from-launcher-settings");
-    }
+  }
   else
-    {
+  {
     CHECK_INT(ctkAppLauncherEnvironment::currentLevel(), 0);
     CHECK_QSTRING(systemEnvironment.value("APPWITHLAUNCHER_ENV_VAR", ""), "");
-    }
+  }
 
   qputenv("APPWITHLAUNCHER_ENV_VAR_ONLY_FROM_EXECUTABLE", "set-only-from-executable");
   qputenv("APPWITHLAUNCHER_ENV_VAR", "set-from-executable");
@@ -591,21 +591,21 @@ int checkEnvironment(bool withLauncher)
   CHECK_QSTRING(systemEnvironment.value("APPWITHLAUNCHER_ENV_VAR", ""), "set-from-executable");
 
   if (withLauncher)
-    {
+  {
     CHECK_QSTRING(ctkAppLauncherEnvironment::environment(0).value("APPWITHLAUNCHER_ENV_VAR", ""), "set-from-launcher-env");
     CHECK_QSTRING(ctkAppLauncherEnvironment::environment(0).value("APPWITHLAUNCHER_ENV_VAR_ONLY_FROM_EXECUTABLE", ""), "");
 
     CHECK_QSTRING(ctkAppLauncherEnvironment::environment(1).value("APPWITHLAUNCHER_ENV_VAR", ""), "set-from-executable");
     CHECK_QSTRING(ctkAppLauncherEnvironment::environment(1).value("APPWITHLAUNCHER_ENV_VAR_ONLY_FROM_EXECUTABLE", ""), "set-only-from-executable");
-    }
+  }
   else
-    {
+  {
     CHECK_QSTRING(ctkAppLauncherEnvironment::environment(0).value("APPWITHLAUNCHER_ENV_VAR", ""), "set-from-executable");
     CHECK_QSTRING(ctkAppLauncherEnvironment::environment(0).value("APPWITHLAUNCHER_ENV_VAR_ONLY_FROM_EXECUTABLE", ""), "set-only-from-executable");
 
     CHECK_QSTRING(ctkAppLauncherEnvironment::environment(1).value("APPWITHLAUNCHER_ENV_VAR", ""), "");
     CHECK_QSTRING(ctkAppLauncherEnvironment::environment(1).value("APPWITHLAUNCHER_ENV_VAR_ONLY_FROM_EXECUTABLE", ""), "");
-    }
+  }
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
_Adapted from similar pull request integrated in Slicer, see https://github.com/Slicer/Slicer/pull/7596_

---

This commit reindents the C++ source files to adhere to the "Allman" style, moving away from the outdated and VTK-specific "Whitesmiths" style. The changes are applied using an approach similar to the one utilized in kitware/VTK@f830ff47b3 ("Reindent using the reindentation script," 2016-09-23).

These modifications are made in anticipation of future changes that will introduce the use of a standard configuration based on clang-format.

Once integrated, this commit will be added to the `.git-blame-ignore-revs`[^1] file.

[^1]: https://github.com/Slicer/Slicer/blob/main/.git-blame-ignore-revs

The script `Utilities/Maintenance/vtk_reindent_code.py` is executed, leveraging the approach from kitware/VTK@6fedbaaffe. The command used is as follows:

```
fd -e cxx -e h -e cpp -e cxx.in -e cpp.in -e h.in -e txx -x \
  python3.12 /path/to/VTK/Utilities/Maintenance/vtk_reindent_code.py {}
```