### PR TITLE
COMP: Remove support for building against Qt4

### DIFF
--- a/Base/Testing/Cpp/CMakeLists.txt
+++ b/Base/Testing/Cpp/CMakeLists.txt
@@ -46,10 +46,10 @@ foreach(file IN ITEMS
     ctkAppLauncherSettingsTest.cpp
     )
   set(moc_file moc_${file})
-  if(CTKAppLauncher_QT_VERSION VERSION_GREATER "4")
+  if(CTKAppLauncher_QT_VERSION VERSION_EQUAL "5")
     QT5_GENERATE_MOC(${file} ${moc_file})
   else()
-    QT4_GENERATE_MOC(${file} ${moc_file})
+    message(FATAL_ERROR "Setting CTKAppLauncher_QT_VERSION to '${CTKAppLauncher_QT_VERSION}' is not supported")
   endif()
   macro_add_file_dependencies(${file} ${CMAKE_CURRENT_BINARY_DIR}/${moc_file})
 endforeach()
@@ -62,11 +62,7 @@ set(${KIT}CppTests_TARGET_LIBRARIES
   CTKAppLauncherBase
   CTKAppLauncherTestingHelper
   )
-if(CTKAppLauncher_QT_VERSION VERSION_GREATER "4")
-  list(APPEND ${KIT}CppTests_TARGET_LIBRARIES Qt5::Test)
-else()
-  list(APPEND ${KIT}CppTests_TARGET_LIBRARIES Qt4::QtTest)
-endif()
+list(APPEND ${KIT}CppTests_TARGET_LIBRARIES Qt${CTKAppLauncher_QT_VERSION}::Test)
 target_link_libraries(${KIT}CppTests PUBLIC ${${KIT}CppTests_TARGET_LIBRARIES} ${QT_LIBRARIES})
 
 if(QT_MAC_USE_COCOA)

--- a/CMake/ctkMacroBuildLib.cmake
+++ b/CMake/ctkMacroBuildLib.cmake
@@ -81,18 +81,14 @@ macro(ctkMacroBuildLib)
   set(${prefix}_QRC_SRCS)
 
   # Wrap
-  if(CTKAppLauncher_QT_VERSION VERSION_LESS "5")
-    QT4_WRAP_CPP(${prefix}_MOC_CXX ${${prefix}_MOC_SRCS})
-    QT4_WRAP_UI(${prefix}_UI_CXX ${${prefix}_UI_FORMS})
-    if(DEFINED ${prefix}_RESOURCES)
-      QT4_ADD_RESOURCES(${prefix}_QRC_SRCS ${${prefix}_RESOURCES})
-    endif()
-  else()
+  if(CTKAppLauncher_QT_VERSION VERSION_EQUAL "5")
     QT5_WRAP_CPP(${prefix}_MOC_CXX ${${prefix}_MOC_SRCS})
     QT5_WRAP_UI(${prefix}_UI_CXX ${${prefix}_UI_FORMS})
     if(DEFINED ${prefix}_RESOURCES)
       QT5_ADD_RESOURCES(${prefix}_QRC_SRCS ${${prefix}_RESOURCES})
     endif()
+  else()
+    message(FATAL_ERROR "Setting CTKAppLauncher_QT_VERSION to '${CTKAppLauncher_QT_VERSION}' is not supported")
   endif()
 
   source_group("Resources" FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,25 +249,19 @@ set(default_qt_version "5")
 set(CTKAppLauncher_QT_VERSION "${default_qt_version}" CACHE STRING "Expected Qt version")
 mark_as_advanced(CTKAppLauncher_QT_VERSION)
 
-set_property(CACHE CTKAppLauncher_QT_VERSION PROPERTY STRINGS 4 5)
+set_property(CACHE CTKAppLauncher_QT_VERSION PROPERTY STRINGS 5)
 
-if(NOT (CTKAppLauncher_QT_VERSION VERSION_EQUAL "4" OR CTKAppLauncher_QT_VERSION VERSION_EQUAL "5"))
-  message(FATAL_ERROR "Expected value for CTKAppLauncher_QT_VERSION is either '4' or '5'")
+if(NOT (CTKAppLauncher_QT_VERSION VERSION_EQUAL "5"))
+  message(FATAL_ERROR "Expected value for CTKAppLauncher_QT_VERSION is '5'")
 endif()
 
-if(CTKAppLauncher_QT_VERSION VERSION_GREATER "4")
+if(CTKAppLauncher_QT_VERSION VERSION_EQUAL "5")
   set(CTKAppLauncher_QT5_COMPONENTS Core Widgets)
   if(BUILD_TESTING)
     list(APPEND CTKAppLauncher_QT5_COMPONENTS Test)
   endif()
   find_package(Qt5 COMPONENTS ${CTKAppLauncher_QT5_COMPONENTS} REQUIRED)
   set(QT_LIBRARIES Qt5::Widgets ${CTKAppLauncher_QT_STATIC_LIBRARIES})
-
-else()
-  set(QT_USE_IMPORTED_TARGETS 1)
-  find_package(Qt4 4.6 REQUIRED)
-  set(QT_USE_QTTEST ${BUILD_TESTING})
-  include(${QT_USE_FILE})
 endif()
 
 #-----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ This system makes the launcher robust and self-contained — no manual backup or
 
 ## Building From Source
 
-To build CTKAppLauncher, you’ll need a C++ compiler, Qt 4.x or 5.x, and CMake 3.16+.
+To build CTKAppLauncher, you’ll need a C++ compiler, Qt 5.x, and CMake 3.16+.
 
 Clone the repository:
 

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -13,14 +13,14 @@ applauncher_add_cmakescript_test(ctkAppLauncherAppendExtraAppToLaunchToListTest 
 applauncher_add_cmakescript_test(ctkAppLauncherExtraAppToLaunchListToQtSettingsTest ctkAppLauncher)
 
 # Get Qt library directory
-if(CTKAppLauncher_QT_VERSION VERSION_GREATER "4")
+if(CTKAppLauncher_QT_VERSION VERSION_EQUAL "5")
   get_target_property(_imported_location "Qt5::Core" IMPORTED_LOCATION_RELEASE)
   get_filename_component(QT_LIBRARY_DIR ${_imported_location} DIRECTORY)
   if(WIN32)
     set(QT_LIBRARY_DIR "${QT_LIBRARY_DIR}/../bin")
   endif()
 else()
-  # QT_LIBRARY_DIR is already set by FindQt4.cmake
+  message(FATAL_ERROR "Setting CTKAppLauncher_QT_VERSION to '${CTKAppLauncher_QT_VERSION}' is not supported")
 endif()
 
 # Run tests against a build tree of CTKAppLauncher

--- a/Testing/LauncherLib/AppWithLauncherLib-ConfigureStep.cmake
+++ b/Testing/LauncherLib/AppWithLauncherLib-ConfigureStep.cmake
@@ -35,14 +35,12 @@ if(DEFINED CTKAppLauncher_QT_STATIC_LIBRARIES)
     -DCTKAppLauncher_QT_STATIC_LIBRARIES:STRING=${CTKAppLauncher_QT_STATIC_LIBRARIES}
     )
 endif()
-if(CTKAppLauncher_QT_VERSION VERSION_GREATER "4")
+if(CTKAppLauncher_QT_VERSION VERSION_EQUAL "5")
   list(APPEND args
     -DQt5_DIR:PATH=${Qt5_DIR}
     )
 else()
-  list(APPEND args
-    -DQT_QMAKE_EXECUTABLE:FILEPATH=${QT_QMAKE_EXECUTABLE}
-    )
+  message(FATAL_ERROR "Setting CTKAppLauncher_QT_VERSION to '${CTKAppLauncher_QT_VERSION}' is not supported")
 endif()
 foreach(varname IN ITEMS
     CMAKE_OSX_ARCHITECTURES

--- a/Testing/LauncherLib/CMakeLists.txt
+++ b/Testing/LauncherLib/CMakeLists.txt
@@ -66,7 +66,7 @@ set(test_args
   -DCMAKE_CXX_FLAGS_${APPLIB_BUILD_TYPE_UC}:STRING=${CMAKE_CXX_FLAGS_${APPLIB_BUILD_TYPE_UC}}
   -DCTKAppLauncher_QT_VERSION:STRING=${CTKAppLauncher_QT_VERSION}
   )
-if(CTKAppLauncher_QT_VERSION VERSION_GREATER "4")
+if(CTKAppLauncher_QT_VERSION VERSION_EQUAL "5")
   list(APPEND test_args
     -DQt5_DIR:PATH=${Qt5_DIR}
     )
@@ -76,9 +76,7 @@ if(CTKAppLauncher_QT_VERSION VERSION_GREATER "4")
       )
   endif()
 else()
-  list(APPEND test_args
-    -DQT_QMAKE_EXECUTABLE:FILEPATH=${QT_QMAKE_EXECUTABLE}
-    )
+  message(FATAL_ERROR "Setting CTKAppLauncher_QT_VERSION to '${CTKAppLauncher_QT_VERSION}' is not supported")
 endif()
 foreach(varname IN ITEMS
     CMAKE_OSX_ARCHITECTURES


### PR DESCRIPTION
All references to Qt4 have been removed and attempts to set CTKAppLauncher_QT_VERSION to '4' will now result in a fatal error.

Note that to support launching Qt4-based applications, the `ArgumentToFilterList` in `appLauncherMain` in `Main.cpp`[^1] still lists Qt4 specific arguments.

[^1]: https://github.com/commontk/AppLauncher/blob/v0.1.32/Main.cpp#L35-L73