### PR TITLE
ci: Upgrade to "macos-14" runner

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -202,8 +202,8 @@ jobs:
   macos-tests:
     needs: changes
     if: ${{ needs.changes.outputs.paths-to-include == 'true' }}
-    runs-on: macos-13
-    name: macos-13
+    runs-on: macos-14
+    name: macos-14
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
The macOS 13 runner will be retired by December 4th, 2025 with scheduled brownout periods in November. See https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

> [!NOTE]
> [Successful testing run](https://github.com/commontk/AppLauncher/actions/runs/17916685791/job/50940625884) ran on macos-14-arm64. If an Intel variant needs to be used, then `macos-15-intel` will have to be specified.